### PR TITLE
fix: remove border color reset on focus

### DIFF
--- a/libs/chlorophyll/scss/common/_focus.scss
+++ b/libs/chlorophyll/scss/common/_focus.scss
@@ -24,7 +24,6 @@
 
   @if $suffix != '' {
     &:focus:not(:focus-visible) {
-      border-color: initial;
       box-shadow: none;
       outline: 0;
     }


### PR DESCRIPTION
removes the `border-color` reset in the common focus mixin, the `initial` value resets value based on web specification and it forces components that uses the mixin to explicitly override them

closes #395 