### PR TITLE
fix(dropdown): popover transitions out on init

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -40,7 +40,7 @@ import {
           label ? toggler?.attributes?.id + '_label' : null
         "
         [attr.aria-describedby]="
-          formInfo?.innerText && formInfo.innerText.length > 0
+          formInfo?.textContent && (formInfo?.textContent?.length ?? 0 > 0)
             ? toggler?.attributes?.id + '_info'
             : null
         "


### PR DESCRIPTION
@hjalmers @JohanObrink 

The angular dropdown popover in mobile is quickly visible at the bottom on page load (it transitions out) - because the classes are missing on the first render so it starts with default styles. Once angular binds the classes on the second render it transitions out. Of course these styles are normally applied from the first render so the transition isn't triggered. 

**The reason:** Angular evaluates bindings as a part of the component lifecycle (not during the template execution) - so if some code triggers a reflow in-between a render will occur before the bound classes are applied. 

One issue of this was caused by a usage of `.innerText` (triggers a reflow) of an element in the template - this is solved in the commit and I think textContent should be fine.

But there are more complex examples that only occur in certain conditions, for example when multiple dropdown are used and one of them is conditionally rendered.

**The problem:** The current setup of the dropdown extract requires references to actual html-elements on creation. References which we cannot retrieve from angular before `ngAfterViewInit` - so we delay the creation until this moment. Once Angular reaches this lifecycle hook the template is already executed - but not yet rendered. Now `createDropdown()` is invoked, and the `pop()` function reads `window.innerWidth`. The reflow causes remaining components to render with missing non-static classes. 

**Conclusion:** I think that we need to restructure extracts in general to avoid problems like this - this will not be unique for the dropdown. Code that causes a reflow should perhaps be handled globally in extracts before initialization of components, or be excluded from extracts and managed as inputs from the "host" application. 

Please add your thoughts, and does a global handling of this seem legit? 