### PR TITLE
Remove <p> tag wrapping {children} in Card

### DIFF
--- a/libs/react/src/lib/card/card.tsx
+++ b/libs/react/src/lib/card/card.tsx
@@ -11,7 +11,7 @@ export function Card({ children, header, footer }: CardProps) {
   return (
     <section className="card">
       <header>{header}</header>
-      <p>{children}</p>
+        {children}
       <footer>{footer}</footer>
     </section>
   )


### PR DESCRIPTION
When the <p> tag is present, we we're seeing warnings in our console-log:
"Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>."