### PR TITLE
fix: 🐛 Configurable font path when setting up use-green-scope

### DIFF
--- a/libs/chlorophyll/scss/components/use-green-scope/_index.scss
+++ b/libs/chlorophyll/scss/components/use-green-scope/_index.scss
@@ -1,11 +1,18 @@
-@use '../../tokens/shame' as tokens;
+$font-path: '../fonts' !default;
+
+@use '../../tokens/shame' as tokens with (
+ $font-path: $font-path
+);
+
 @use '../reset/mixins' as mixins;
 @use '../themes/mixins' as themes;
+
 
 /* add variables for light mode to `.use-green` class */
 .use-green {
   @include tokens.light-mode;
   @include themes.add-theme();
 }
+
 /* apply reset mixin on `.use-green` class to reset container and child elements */
 @include mixins.reset('.use-green');

--- a/libs/chlorophyll/stories/use cases/mixing frameworks/use-green-in-shells.stories.mdx
+++ b/libs/chlorophyll/stories/use cases/mixing frameworks/use-green-in-shells.stories.mdx
@@ -16,6 +16,10 @@ It could look something like this:
 ```css
 /* Add use-green scope i.e. ability to use (`.use-green`) */
 @use '@sebgroup/chlorophyll/scss/components/use-green-scope';
+/* if you need to configure $font-path variable you do it here by adding like this:
+@use '@sebgroup/chlorophyll/scss/components/use-green-scope' with (
+  $font-path: './path/to/seb/font'
+); /*
 
 /* Import green and scope it to `.use-green` class and our root element (by default app-root in angular but you should change it).
 We use app-root here to make sure no CSS is applied to other elements except our MFE which will be rendered inside the `<app-root>` tag.


### PR DESCRIPTION
When setting up use-green scope it was not possible to configure font path. Now you can do it by adding a config to the import of use-green-scope