### PR TITLE
Feature: iFrame Canvas Mode

### DIFF
--- a/.storybook/addons/iframe-canvas-mode/manager.js
+++ b/.storybook/addons/iframe-canvas-mode/manager.js
@@ -27,10 +27,15 @@ export function initIFrameCanvasMode() {
       },
     })
     
-    if (localStorage["storybook-layout"]) {
-      const storybookLayout = JSON.parse(localStorage["storybook-layout"]);
-      const newLayout = { resizerPanel: { x: window.innerWidth - 320, y: 0 }};
-      localStorage["storybook-layout"] = JSON.stringify({...storybookLayout, ...newLayout});
+    let storybookConfig = JSON.parse(localStorage.getItem('storybook-layout'));
+    if (typeof storybookConfig === 'object' && storybookConfig !== null && storybookConfig.resizerNav.x < 320) {
+      storybookConfig.resizerPanel.x = window.innerWidth - 320;
+      localStorage.setItem('storybook-layout', JSON.stringify(storybookConfig));
+      document.location.reload();
+    } else if (storybookConfig === null) {
+      storybookConfig = { resizerNav: { x: 320, y: 0 }, resizerPanel: { x: window.innerWidth - 320, y: 0 } };
+      localStorage.setItem('storybook-layout', JSON.stringify(storybookConfig));
+      document.location.reload();
     }
 
     const style = document.createElement('style')

--- a/.storybook/addons/iframe-canvas-mode/manager.js
+++ b/.storybook/addons/iframe-canvas-mode/manager.js
@@ -1,0 +1,45 @@
+/**
+ * This addon enables a query parameter to specify "iframe canvas mode".
+ * Essentially, it hides the nav menu and tool bar, leaving only the canvas and controls panel.
+ * Useful for embeddning a component canvas with controls on another website.
+*/
+
+import { addons } from '@storybook/addons';
+
+export function initIFrameCanvasMode() {
+  const queryParams = new URLSearchParams(window.location.search)
+
+  if (queryParams.get('iframeCanvasMode') == 'true') {
+    addons.setConfig({
+      showNav: false,
+      showPanel: true,
+      panelPosition: 'right',
+      enableShortcuts: false,
+      showToolbar: false,
+      selectedPanel: undefined,
+      initialActive: 'canvas',
+      toolbar: {
+        title: { hidden: true },
+        zoom: { hidden: false },
+        eject: { hidden: true },
+        copy: { hidden: true },
+        fullscreen: { hidden: true },
+      },
+    })
+    
+    if (localStorage["storybook-layout"]) {
+      const storybookLayout = JSON.parse(localStorage["storybook-layout"]);
+      const newLayout = { resizerPanel: { x: window.innerWidth - 320, y: 0 }};
+      localStorage["storybook-layout"] = JSON.stringify({...storybookLayout, ...newLayout});
+    }
+
+    const style = document.createElement('style')
+    style.textContent = `
+      [aria-label="Show sidebar"],
+      [aria-label="Show sidebar"] + * {
+        display: none !important;
+      }
+    `
+    document.head.appendChild(style)
+  }
+}

--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,2 +1,6 @@
 // import scss using scss-loader file
 import '!style-loader!css-loader!postcss-loader!sass-loader!./manager.scss'
+
+import { initIFrameCanvasMode } from './addons/iframe-canvas-mode/manager'
+
+initIFrameCanvasMode();

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -8,6 +8,7 @@ export const parameters = {
     light,
     stylePreview: true,
     darkClass: 'dark-mode',
+    current: 'light'
   },
   viewMode: 'docs'
 }


### PR DESCRIPTION
This PR adds a querystring param to Storybook, which customizes the layout so the Canvas with Controls panel can be embedded in an iframe.

Here's an example:
![image](https://user-images.githubusercontent.com/428824/186636910-42c3d3ef-c8f2-4704-b5c7-d40c16554d3c.png)

It's activated by adding `iframeCanvasMode=true` to the Storybook URL.