### PR TITLE
refactor: 💡 changing popover class due to IBP conflict

### DIFF
--- a/apps/react-lib-dev/src/app/app.tsx
+++ b/apps/react-lib-dev/src/app/app.tsx
@@ -4,10 +4,10 @@ import {IValidator} from "@sebgroup/extract";
 
 const dropDownKeyValueArray = [
   {
-    key: 'Apple',
+    label: 'Apple',
     value: 'apple'
   }, {
-    key: 'Banana',
+    label: 'Banana',
     value: 'banana'
   }
 ]

--- a/libs/chlorophyll/scss/components/popover/_index.scss
+++ b/libs/chlorophyll/scss/components/popover/_index.scss
@@ -5,7 +5,7 @@
 @use '../../components/close';
 @use '../../components/utility';
 
-.popover {
+.popover, ._popover {
   @include mixins.popover;
 }
 

--- a/libs/extract/src/lib/dropdown/defaultValues.ts
+++ b/libs/extract/src/lib/dropdown/defaultValues.ts
@@ -14,7 +14,7 @@ export const dropdownValues: Partial<AbstractDropdown> = {
         role: 'listbox',
         tabIndex: -1,
       },
-      classes: ['popover', 'popover-dropdown'],
+      classes: ['_popover', 'popover-dropdown'],
     },
   },
   isActive: false,


### PR DESCRIPTION
elements with the class popover gets removed by global scripts. prefixing the class with _ until the script is removed.

✅ Closes: #560