### PR TITLE
feat(storybook): add preset addon for DL json

### DIFF
--- a/.storybook/addons/designlibrary/generate-json-preset.js
+++ b/.storybook/addons/designlibrary/generate-json-preset.js
@@ -42,18 +42,13 @@ module.exports = {
       const jsonOutput = await Promise.all(
         Object.keys(storyPaths).map(async (absPath) => {
           const csf = (await csfTools.readCsfOrMdx(absPath, {})).parse()
-          //if (csf.meta.title == 'Components/Modal')
-            //console.log(util.inspect(csf._storyAnnotations, {showHidden: false, depth: null, colors: true}))
           return csf.stories.map(story => ({
             id: story.id,
             name: story.name,
             title: csf.meta.title,
             customParams: {
-              ...csf._metaAnnotations.parameters?.properties.reduce((acc, cur) => ({
-                ...acc,
-                ...{ [cur.key.name]: cur.value.value || cur.value.elements?.map(e => e.value) }
-              }), {}),
-              ...getParametersFromCSF(csf, story.name)
+              ...getMetaParametersFromCSF(csf),
+              ...getStoryParametersFromCSF(csf, story.name)
             },
           }))
         })
@@ -83,7 +78,13 @@ module.exports = {
   },
 }
 
-getParametersFromCSF = (csf, storyName) => {
+const getMetaParametersFromCSF = (csf) =>
+  csf._metaAnnotations.parameters?.properties.reduce((acc, cur) => ({
+    ...acc,
+    ...{ [cur.key.name]: cur.value.value || cur.value.elements?.map(e => e.value) }
+  }), {})
+
+const getStoryParametersFromCSF = (csf, storyName) => {
   const storyAnnotations = csf._storyAnnotations;
   
   let storyParams;

--- a/.storybook/addons/designlibrary/generate-json-preset.js
+++ b/.storybook/addons/designlibrary/generate-json-preset.js
@@ -1,0 +1,65 @@
+// This addon generates a json file similar to stories.json, but tailored for Design Library
+
+const fs = require('fs')
+
+const csfTools = require('@storybook/csf-tools')
+const nodeLogger = require('@storybook/node-logger')
+const coreCommon = require('@storybook/core-common')
+
+module.exports = {
+  // We're not actually modifying the webpack config here,
+  // just using this hook to execute code during the build process.
+  webpackFinal: async (config, options) => {
+    const { default: slash } = await import('slash')
+    const { default: path } = await import('path')
+    const { globby: globby } = await import('globby')
+
+    nodeLogger.logger.info('=> Generating custom json for Design Library...')
+
+    var directories = {
+      configDir: options.configDir,
+      workingDir: process.cwd(),
+    }
+    const storySpecifiers = coreCommon.normalizeStories(
+      await options.presets.apply('stories'),
+      directories
+    )
+    const storyPaths = {}
+
+    await Promise.all(
+      storySpecifiers.map(async (s) => {
+        const fullGlob = slash(
+          path.join(directories.workingDir, s.directory, s.files)
+        )
+        const files = await globby(fullGlob)
+        files.forEach((file) => (storyPaths[file] = false))
+      })
+    )
+
+    const jsonOutput = await Promise.all(
+      Object.keys(storyPaths).map(async (absPath) => {
+        const csf = (await csfTools.readCsfOrMdx(absPath, {})).parse()
+        return {
+          id: csf.stories[0].id,
+          name: csf.stories[0].name,
+          title: csf.meta.title,
+          customParams:
+            csf._metaAnnotations.parameters?.properties.map((p) => ({
+              [p.key.name]: p.value.value,
+            })) || [],
+        }
+      })
+    )
+    
+    const dlJsonPath = path.join(options.outputDir, 'designlibrary.json')
+    fs.writeFile(dlJsonPath, JSON.stringify(jsonOutput, null, 2), (error) => {
+      if (error) {
+        nodeLogger.logger.error(`=> An error has occurred writing Design Library json to ${dlJsonPath}`, error)
+        return
+      }
+      nodeLogger.logger.info(`=> Design Library json written to ${dlJsonPath}`)
+    })
+
+    return config
+  },
+}

--- a/.storybook/addons/designlibrary/generate-json-preset.js
+++ b/.storybook/addons/designlibrary/generate-json-preset.js
@@ -46,7 +46,7 @@ module.exports = {
           customParams:
             csf._metaAnnotations.parameters?.properties.reduce((acc, cur) => ({
               ...acc,
-              ...{ [cur.key.name]: cur.value.value }
+              ...{ [cur.key.name]: cur.value.value || cur.value.elements.map(e => e.value) }
             }), {}) || {},
         }
       })

--- a/.storybook/addons/designlibrary/generate-json-preset.js
+++ b/.storybook/addons/designlibrary/generate-json-preset.js
@@ -44,9 +44,10 @@ module.exports = {
           name: csf.stories[0].name,
           title: csf.meta.title,
           customParams:
-            csf._metaAnnotations.parameters?.properties.map((p) => ({
-              [p.key.name]: p.value.value,
-            })) || [],
+            csf._metaAnnotations.parameters?.properties.reduce((acc, cur) => ({
+              ...acc,
+              ...{ [cur.key.name]: cur.value.value }
+            }), {}) || {},
         }
       })
     )

--- a/.storybook/addons/designlibrary/generate-json-preset.js
+++ b/.storybook/addons/designlibrary/generate-json-preset.js
@@ -64,7 +64,7 @@ module.exports = {
         nodeLogger.logger.info(`Design Library json written to ${dlJsonPath}`)
       })
     } catch(error) {
-      nodeLogger.logger.warn(`An error has occurred while generating json for Design Library`, error)
+      nodeLogger.logger.warn(`An error has occurred while generating json for Design Library`)
       nodeLogger.logger.warn(error)
     }
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,6 +17,7 @@ module.exports = {
     '@storybook/addon-a11y',
     'storybook-dark-mode',
     path.resolve('./.storybook/addons/run-in-iframe/run-in-iframe-preset.js'),
+    path.resolve('./.storybook/addons/designlibrary/generate-json-preset.js'),
     {
       name: '@storybook/addon-postcss',
       options: {

--- a/libs/chlorophyll/scss/components/alert/alert.stories.mdx
+++ b/libs/chlorophyll/scss/components/alert/alert.stories.mdx
@@ -57,7 +57,7 @@ export const Template = ({
 # Alert
 
 <Story
-    name="examples"
+    name="example"
     args={{
       type: 'success',
       heading: 'Success!',
@@ -66,9 +66,6 @@ export const Template = ({
       button: '',
       primaryButton: '',
       closeButton: false
-    }}
-    parameters={{ 
-      testParam: 'derp'
     }}
   >
     {Template.bind({})}

--- a/libs/chlorophyll/scss/components/alert/alert.stories.mdx
+++ b/libs/chlorophyll/scss/components/alert/alert.stories.mdx
@@ -31,6 +31,9 @@ export const Template = ({
 
 <Meta
   title="Components/Alert"
+  parameters={{
+    componentIds: ['component-alertribbon']
+  }}
   argTypes={{
     type: {
       control: 'select',
@@ -54,7 +57,7 @@ export const Template = ({
 # Alert
 
 <Story
-    name="example"
+    name="examples"
     args={{
       type: 'success',
       heading: 'Success!',
@@ -63,6 +66,9 @@ export const Template = ({
       button: '',
       primaryButton: '',
       closeButton: false
+    }}
+    parameters={{ 
+      testParam: 'derp'
     }}
   >
     {Template.bind({})}

--- a/libs/chlorophyll/scss/components/badge/badge.stories.mdx
+++ b/libs/chlorophyll/scss/components/badge/badge.stories.mdx
@@ -13,6 +13,9 @@ export const Template = ({ variant, dismissible, text }) => {
 
 <Meta
   title="Components/Badge"
+  parameters={{
+    componentIds: ['component-badge']
+  }}
   argTypes={{
     variant: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/button/button.stories.mdx
+++ b/libs/chlorophyll/scss/components/button/button.stories.mdx
@@ -8,6 +8,9 @@ export const Template = ({ type, variant, text }) => {
 
 <Meta
   title="Components/Form/Elements/Button"
+  parameters={{ 
+    componentIds: ['component-button']
+  }}
   argTypes={{
     type: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/card/card.stories.mdx
+++ b/libs/chlorophyll/scss/components/card/card.stories.mdx
@@ -22,6 +22,9 @@ export const Template = ({ heading,closeButton, body, button, primaryButton, lin
 
 <Meta
   title="Components/Card"
+  parameters={{ 
+    componentIds: ['component-card']
+  }}
   argTypes={{
     heading: { control: 'text' },
     body: { control: 'text' },

--- a/libs/chlorophyll/scss/components/datepicker/datepicker.stories.mdx
+++ b/libs/chlorophyll/scss/components/datepicker/datepicker.stories.mdx
@@ -95,6 +95,9 @@ export const Template = ({ validation, enabled, text }) => {
 
 <Meta
   title="Components/Datepicker"
+  parameters={{ 
+    componentId: ['component-datepicker']
+  }}
 />
 
 <Story

--- a/libs/chlorophyll/scss/components/datepicker/datepicker.stories.mdx
+++ b/libs/chlorophyll/scss/components/datepicker/datepicker.stories.mdx
@@ -96,7 +96,7 @@ export const Template = ({ validation, enabled, text }) => {
 <Meta
   title="Components/Datepicker"
   parameters={{ 
-    componentId: ['component-datepicker']
+    componentIds: ['component-datepicker']
   }}
 />
 

--- a/libs/chlorophyll/scss/components/dropdown/dropdown.stories.mdx
+++ b/libs/chlorophyll/scss/components/dropdown/dropdown.stories.mdx
@@ -21,7 +21,7 @@ export const Template = ({ validation, enabled, text }) => {
 <Meta
   title="Components/Dropdown"
   parameters={{ 
-    componentId: ['component-dropdown']
+    componentIds: ['component-dropdown']
   }}
   argTypes={{
     validation: {

--- a/libs/chlorophyll/scss/components/dropdown/dropdown.stories.mdx
+++ b/libs/chlorophyll/scss/components/dropdown/dropdown.stories.mdx
@@ -20,6 +20,9 @@ export const Template = ({ validation, enabled, text }) => {
 
 <Meta
   title="Components/Dropdown"
+  parameters={{ 
+    componentId: ['component-dropdown']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
@@ -14,7 +14,7 @@ export const Template = ({ validation, enabled, text }) => {
 <Meta
   title="Components/Form/Elements/Checkbox"
   parameters={{ 
-    componentId: ['component-checkbox']
+    componentIds: ['component-checkbox']
   }}
   argTypes={{
     validation: {

--- a/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
@@ -13,6 +13,9 @@ export const Template = ({ validation, enabled, text }) => {
 
 <Meta
   title="Components/Form/Elements/Checkbox"
+  parameters={{ 
+    componentId: ['component-checkbox']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/form/input/input.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/input/input.stories.mdx
@@ -15,6 +15,9 @@ export const Template = ({ validation, enabled, text, formInfo }) => {
 
 <Meta
   title="Components/Form/Elements/Input"
+  parameters={{ 
+    componentIds: ['component-input']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/form/radio/radio.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/radio/radio.stories.mdx
@@ -16,6 +16,9 @@ export const Template = ({ validation, enabled, text1, text2 }) => {
 
 <Meta
   title="Components/Form/Elements/Radio button"
+  parameters={{ 
+    componentIds: ['component-radiobutton']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/form/stepper/stepper.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/stepper/stepper.stories.mdx
@@ -19,6 +19,9 @@ export const Template = ({ validation, enabled, text, formInfo }) => {
 
 <Meta
   title="Components/Form/Elements/Stepper"
+  parameters={{ 
+    componentIds: ['component-stepper']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/form/textarea/textarea.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/textarea/textarea.stories.mdx
@@ -15,6 +15,9 @@ export const Template = ({ validation, enabled, text, formInfo }) => {
 
 <Meta
   title="Components/Form/Elements/Textarea"
+  parameters={{ 
+    componentIds: ['component-input']
+  }}
   argTypes={{
     validation: {
       control: 'select',

--- a/libs/chlorophyll/scss/components/link/link.stories.mdx
+++ b/libs/chlorophyll/scss/components/link/link.stories.mdx
@@ -6,6 +6,9 @@ export const Template = ({ text, className }) => `
 
 <Meta
   title="Components/Links"
+  parameters={{ 
+    componentIds: ['component-inlinelinks']
+  }}
   argTypes={{
     text: { control: 'text' },
     className: {

--- a/libs/chlorophyll/scss/components/list/list.stories.mdx
+++ b/libs/chlorophyll/scss/components/list/list.stories.mdx
@@ -1,6 +1,11 @@
 import { Meta, Canvas } from '@storybook/addon-docs/blocks'
 
-<Meta title="Components/List/Ordered" />
+<Meta
+  title="Components/List/Ordered"
+  parameters={{ 
+    componentIds: ['component-list']
+  }}
+/>
 
 ### Ordered list
 <Canvas>

--- a/libs/chlorophyll/scss/components/modal/modal.stories.mdx
+++ b/libs/chlorophyll/scss/components/modal/modal.stories.mdx
@@ -1,6 +1,14 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'; import {background} from "@storybook/theming";
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { background } from "@storybook/theming";
 
-export const Template = ({ headline, body }) => {
+<Meta
+  title="Components/Modal"
+  argTypes={{
+    headline: { control: 'text' },
+    body: { control: 'text' },
+  }} />
+
+export const DialogueTemplate = ({ headline, body }) => {
   return `
     <section role='dialog'
            aria-modal="true"
@@ -21,32 +29,48 @@ export const Template = ({ headline, body }) => {
   </section>`
 }
 
-<Meta
-  title="Components/Modal"
-  parameters={{ 
-    componentIds: [
-      'component-dialogue',
-      'component-foldout',
-      'component-slideout',
-      'component-slideup',
-      'component-takeover'
-    ]
-  }}
-  argTypes={{
-    headline: { control: 'text' },
-    body: { control: 'text' },
-  }} />
+export const SlideoutTemplate = ({ headline, body }) => {
+  return `
+    <aside role='dialog'
+         role='dialog'
+         aria-modal="true"
+         aria-labelledby="modal_header"
+         aria-describedby="modal_body">
+    <header>
+      <h3 id="modal_header">${headline}</h3>
+      <button class='close'>
+        <span class='sr-only'>Close</span>
+      </button>
+    </header>
+    <div class='body' id="modal_body">
+      ${body}
+    </div>
+    <footer>
+      <button type="button">Secondary</button><button type="submit">Primary</button>
+    </footer>
+  </aside>`
+}
 
-<Story
-  name="Modal"
-  args={{
-    headline: 'Modal headline',
-    body: '<p>Modal body text. Lorem ipsum dolor sit amet.</p>'
-  }}
-  parameters={{ docs: { disable: true }}}
->
-  {Template.bind({})}
-</Story>
+export const TakeoverTemplate = ({ headline, body }) => {
+  return `
+    <main role='dialog'
+        aria-modal="true"
+        aria-labelledby="modal_header"
+        aria-describedby="modal_body">
+    <header>
+      <h3 id="modal_header">${headline}</h3>
+      <button class='close'>
+        <span class='sr-only'>Close</span>
+      </button>
+    </header>
+    <div class='body' id="modal_body">
+      ${body}
+    </div>
+    <footer>
+      <button type="button">Secondary</button><button type="submit">Primary</button>
+    </footer>
+  </main>`
+}
 
 <style>{
   `
@@ -89,53 +113,46 @@ export const Template = ({ headline, body }) => {
 
 Green currently provides three different variants of the modal - **dialog**, **aside** (aka slide out) and **fullscreen** (aka take over).
 
-### Dialog
+### Dialogue
 
 Dialog modals are typically used for confirming actions or displaying information that the user must act on before continuing with intended flow.
 
 <Canvas>
-  <section role='dialog'
-           aria-modal="true"
-           aria-labelledby="modal_header"
-           aria-describedby="modal_body">
-    <header>
-      <h3 id="modal_header">Header</h3>
-      <button class='close'>
-        <span class='sr-only'>Close</span>
-      </button>
-    </header>
-    <div class='body' id="modal_body">
-      <p>Modal body</p>
-    </div>
-    <footer>
-      <button type="button">Secondary</button><button type="submit">Primary</button>
-    </footer>
-  </section>
+  <Story
+    name="Dialogue"
+    parameters={{ 
+      componentIds: [
+        'component-dialogue'
+      ]
+    }}
+    args={{
+      headline: 'Dialogue headline',
+      body: '<p>Modal body text. Lorem ipsum dolor sit amet.</p>'
+    }}
+  >
+    {DialogueTemplate.bind({})}
+  </Story>
 </Canvas>
 
-### Aside
+### Slide-out
 
 Aside modals or slide out modals are typically used for displaying details regarding some information, i.e. transaction details in a list of transactions. It slides in from the right on desktop and from the bottom of the viewport on smaller screens like mobile devices.
 
 <Canvas>
-  <aside role='dialog'
-         role='dialog'
-         aria-modal="true"
-         aria-labelledby="modal_header"
-         aria-describedby="modal_body">
-    <header>
-      <h3 id="modal_header">Header</h3>
-      <button class='close'>
-        <span class='sr-only'>Close</span>
-      </button>
-    </header>
-    <div class='body' id="modal_body">
-      <p>Modal body</p>
-    </div>
-    <footer>
-      <button type="button">Secondary</button><button type="submit">Primary</button>
-    </footer>
-  </aside>
+  <Story
+    name="Slide-out"
+    parameters={{ 
+      componentIds: [
+        'component-slideout'
+      ]
+    }}
+    args={{
+      headline: 'Slideout headline',
+      body: '<p>Modal body text. Lorem ipsum dolor sit amet.</p>'
+    }}
+  >
+    {SlideoutTemplate.bind({})}
+  </Story>
 </Canvas>
 
 ### Fullscreen
@@ -143,23 +160,20 @@ Aside modals or slide out modals are typically used for displaying details regar
 Fullscreen modals or takeovers are typically used for wizards or for complex flows requiring a lot of screen estate.
 
 <Canvas>
-  <main role='dialog'
-        aria-modal="true"
-        aria-labelledby="modal_header"
-        aria-describedby="modal_body">
-    <header>
-      <h3 id="modal_header">Header</h3>
-      <button class='close'>
-        <span class='sr-only'>Close</span>
-      </button>
-    </header>
-    <div class='body' id="modal_body">
-      <p>Modal body</p>
-    </div>
-    <footer>
-      <button type="button">Secondary</button><button type="submit">Primary</button>
-    </footer>
-  </main>
+  <Story
+    name="Takeover"
+    parameters={{ 
+      componentIds: [
+        'component-takeover'
+      ]
+    }}
+    args={{
+      headline: 'Takeover headline',
+      body: '<p>Modal body text. Lorem ipsum dolor sit amet.</p>'
+    }}
+  >
+    {TakeoverTemplate.bind({})}
+  </Story>
 </Canvas>
 
 

--- a/libs/chlorophyll/scss/components/modal/modal.stories.mdx
+++ b/libs/chlorophyll/scss/components/modal/modal.stories.mdx
@@ -23,6 +23,15 @@ export const Template = ({ headline, body }) => {
 
 <Meta
   title="Components/Modal"
+  parameters={{ 
+    componentIds: [
+      'component-dialogue',
+      'component-foldout',
+      'component-slideout',
+      'component-slideup',
+      'component-takeover'
+    ]
+  }}
   argTypes={{
     headline: { control: 'text' },
     body: { control: 'text' },

--- a/libs/chlorophyll/scss/components/navbar/navbar.stories.mdx
+++ b/libs/chlorophyll/scss/components/navbar/navbar.stories.mdx
@@ -15,6 +15,9 @@ export const Template = ({ text }) => {
 
 <Meta
   title="Components/Navbar"
+  parameters={{ 
+    componentIds: []
+  }}
   argTypes={{
     text: { control: 'text' },
   }} />

--- a/libs/chlorophyll/scss/components/skeleton-loader/skeleton-loader.stories.mdx
+++ b/libs/chlorophyll/scss/components/skeleton-loader/skeleton-loader.stories.mdx
@@ -1,6 +1,11 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
 
-<Meta title="Components/Skeleton loader" />
+<Meta
+  title="Components/Skeleton loader"
+  parameters={{ 
+    componentIds: ['component-skeleton-loader']
+  }}  
+/>
 
 # Skeleton loader
 

--- a/libs/chlorophyll/scss/components/slide-toggle/slide-toggle.stories.mdx
+++ b/libs/chlorophyll/scss/components/slide-toggle/slide-toggle.stories.mdx
@@ -10,6 +10,9 @@ export const Template = ({ label, checked }) => `
 
 <Meta
   title="Components/Slide Toggle"
+  parameters={{ 
+    componentIds: ['component-slidetoggle']
+  }}
   argTypes={{
     label: { control: 'text' },
     checked: {

--- a/libs/chlorophyll/scss/components/table/table.stories.mdx
+++ b/libs/chlorophyll/scss/components/table/table.stories.mdx
@@ -1,6 +1,11 @@
 import { Meta, Canvas } from '@storybook/addon-docs'
 
-<Meta title="Components/Table" />
+<Meta
+  title="Components/Table"
+  parameters={{ 
+    componentIds: ['component-table']
+  }}
+/>
 
 # Table
 

--- a/libs/chlorophyll/scss/components/tabs-bar/tabs.stories.mdx
+++ b/libs/chlorophyll/scss/components/tabs-bar/tabs.stories.mdx
@@ -28,7 +28,12 @@ export const Template = () => {
     </div>`
 }
 
-<Meta title="Components/Tabs" />
+<Meta
+  title="Components/Tabs"
+  parameters={{ 
+    componentIds: ['component-tab']
+  }}  
+/>
 
 <Story
   name="Tabs"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "browserslist": "^4.20.2",
     "core-js": "^3.22.1",
     "date-fns": "^2.28.0",
+    "globby": "^13.1.2",
     "inputmask": "^5.0.7",
     "merge": "^2.1.1",
     "node-sass": "^7.0.1",
@@ -209,4 +210,3 @@
     "trim-newlines": "^3.0.1"
   }
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -10850,6 +10850,17 @@ globby@^13.1.1:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+globby@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
+  integrity sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
 globby@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-9.2.0.tgz#fd029a706c703d29bdd170f4b6db3a3f7a7cb63d"


### PR DESCRIPTION
This PR adds a Storybook preset addon which generates a json file similar to stories.json, but tailored for Design Library.
This will allow us to specify Design Library component IDs on stories, so they can be automatically matched to a component page in Dersign Library.

The component IDs are specified in the `parameters` metadata of a story:
```jsx
<Meta
  title="Components/Alert"
  parameters={{
    componentIds: ['component-alertribbon']
  }}
/>
```

Some stories may relate to several components in Design Library, so multiple IDs can be specified:
```jsx
<Meta
  title="Components/Modal"
  parameters={{ 
    componentIds: [
      'component-dialogue',
      'component-foldout',
      'component-slideout',
      'component-slideup',
      'component-takeover'
    ]
  }}
/>
```

IDs can also be specified on a sub-story level:
```jsx
<Story
    name="Takeover"
    parameters={{ 
      componentIds: [
        'component-takeover'
      ]
    }}
    args={{
      headline: 'Takeover headline',
      body: '<p>Modal body text. Lorem ipsum dolor sit amet.</p>'
    }}
  >
    {TakeoverTemplate.bind({})}
</Story>
```

Parameters added in the metadata will apply to all stories in the file.

This is the file that gets generated: https://sebgroup.github.io/green/pr-622/chlorophyll/designlibrary.json