### PR TITLE
style: 💄 removing red from charts

### DIFF
--- a/libs/charts/scss/mixins.scss
+++ b/libs/charts/scss/mixins.scss
@@ -31,14 +31,10 @@ $min-height: 3.5rem;
 @mixin add-color-palettes() {
   /*-- Default color pattern --*/
   .bb-color-pattern {
-    background-image: url('#45B400;#0092E1;#FFB400;#D81A1A;#4F2C99;#8AAEC7;#FF7E5A;#898EFE;#FFAC35;#70B0FF;');
+    background-image: url('#45B400;#0092E1;#FFB400;#4F2C99;#8AAEC7;#898EFE;#FFAC35;#70B0FF;');
 
     &.blue {
       background-image: url('#0000ff;0000cc;#000099;#EF65A2;#A377FE;#8AAEC7;#FF7E5A;#898EFE;#FFAC35;#70B0FF;');
-    }
-
-    &.red {
-      background-image: url('#65CFC2;#D0A45F;#64A4F5;#EF65A2;#A377FE;#8AAEC7;#FF7E5A;#898EFE;#FFAC35;#70B0FF;');
     }
 
     &.green {


### PR DESCRIPTION
Red was seen as a negative color by users so it should not be used in charts