### PR TITLE
fix: 🐛 FormControl touched property update/reset fix

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -171,10 +171,12 @@ export class NggDropdownComponent
       searchFilter: this.searchFilter,
       compareWith: this.compareWith,
       onTouched: () => {
-        this.onTouchedFn?.()
         this.touched.emit(true)
         this.cd.markForCheck()
       },
+      onBlur: () => {
+        this.onTouchedFn?.()
+      }
     }
   }
 

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -44,6 +44,7 @@ export const createDropdown = (
     onChange,
     onDestroy$: new Subject<void>(),
     onTouched: init.onTouched,
+    onBlur: init?.onBlur,
   } as DropdownHandler
 
   handler.active = (isActive) =>
@@ -74,6 +75,7 @@ export const createDropdown = (
     .pipe(takeUntil(handler.onDestroy$))
     .subscribe(() => {
       handler.blur()
+      handler.onBlur?.()
     })
 
   merge(fromEvent(toggler, 'focusin'), fromEvent(toggler, 'click'))

--- a/libs/extract/src/lib/dropdown/types.ts
+++ b/libs/extract/src/lib/dropdown/types.ts
@@ -78,6 +78,7 @@ export interface DropdownArgs {
   multiSelect?: boolean
   searchable?: boolean
   onTouched?: () => void
+  onBlur?: () => void
   validator?: IValidator
   compareWith?: CompareWith
   searchFilter?: SearchFilter
@@ -93,6 +94,7 @@ export interface DropdownHandler {
   onChange: OnChange
   onDestroy$: Subject<void>
   onTouched?: () => void
+  onBlur?: () => void
 
   update: (props: DropdownArgs) => Promise<void>
   blur: () => Promise<void>


### PR DESCRIPTION
FormControl touched property should be updated after blur event and should be untouched after control reset() is called

BREAKING CHANGE: 🧨 -

✅ Closes: -

After formControl.reset() is called status should be reset and later marked as touched on blur event.

```
True if the control is marked as touched.

A control is marked touched once the user has triggered a blur event on it.
```
https://angular.io/api/forms/AbstractControl#touched