### PR TITLE
fix(stepper): only emit onChange on user events

### DIFF
--- a/libs/extract/src/lib/stepper/stepper.spec.ts
+++ b/libs/extract/src/lib/stepper/stepper.spec.ts
@@ -1,11 +1,17 @@
+import { SetStateAction } from 'react'
 import { createStepper, AbstractStepper, StepperData } from './stepper'
 
 describe('stepper', () => {
   let stepper: AbstractStepper
   let data: StepperData
 
-
-  const setData = (_data: StepperData) => { data = _data }
+  const setData = (state: SetStateAction<StepperData>) => {
+    if (typeof state === 'function') {
+      data = state(data)
+    } else if (typeof state === 'object') {
+      data = state
+    }
+  }
 
   it('instantiates and sets data', () => {
     stepper = createStepper({ }, setData)

--- a/libs/react/src/lib/stepper/hook.ts
+++ b/libs/react/src/lib/stepper/hook.ts
@@ -7,7 +7,7 @@ export { StepperArgs }
 const noop = () => {}
 
 export const useStepper = (
-  { min, max, value = 0, step = 1, id = randomId() }: StepperArgs,
+  { min, max, value = 0, step = 1, id = randomId(), onChange }: StepperArgs,
 ): [AbstractStepper, StepperData] => {
   const pStepper: Partial<AbstractStepper> = {
     down: noop,
@@ -23,10 +23,10 @@ export const useStepper = (
   useEffect(() => { if (max !== data.max) stepper.setMax(max) }, [stepper, max])
   useEffect(() => { if (min !== data.min) stepper.setMin(min) }, [stepper, min])
   useEffect(() => { if (step !== data.step) stepper.setStep(step || 1) }, [stepper, step])
-  useEffect(() => { if (value !== data.value) stepper.setValue(value || 0) }, [stepper, value])
+  useEffect(() => { if (value !== data.value) stepper.setValue(value || 0, false) }, [stepper, value])
 
   useEffect(() => {
-    setStepper(createStepper({ id, value, min, max, step }, setData))
+    setStepper(createStepper({ id, value, min, max, step, onChange }, setData))
   }, [])
 
   return [stepper, data]

--- a/libs/react/src/lib/stepper/stepper.tsx
+++ b/libs/react/src/lib/stepper/stepper.tsx
@@ -1,27 +1,20 @@
-import React, {useEffect, ChangeEvent} from 'react'
+import {ChangeEvent} from 'react'
 import { StepperArgs, useStepper } from './hook'
 
 export interface StepperProps extends StepperArgs {
   label?: string
   description?: string
   statusMessage?: string
-  onChange?: (value: number) => void
 }
 
 export function Stepper({
   label,
   description,
   statusMessage,
-  onChange,
-  ...props
+  ...stepperArgs
 }: StepperProps) {
 
-  const [stepper, data] = useStepper(props)
-
-  useEffect(() => {
-    if ( typeof data.value === 'undefined' ) return
-    if (onChange) onChange(data.value)
-  }, [data.value])
+  const [stepper, data] = useStepper(stepperArgs)
 
   const onChangeEvent = (e: ChangeEvent<HTMLInputElement>) => {
     stepper.setValue(e.target.valueAsNumber)


### PR DESCRIPTION
onChange should not be emitted when the stepper is created - and not when setting the value from a parent component (eg: when the component is used like a controlled input)