### PR TITLE
style: 💄 Checkbox, fieldset, forminfo and validation

### DIFF
--- a/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/checkbox/_mixins.scss
@@ -22,7 +22,7 @@ $invalid-color: tokens.$intent-danger-background;
   }
 
   /* Add focus to form-control field */
-  #{$selector} {
+  #{$selector}:has( input[type="checkbox"]:focus-visible) {
     @include common.add-focus('within');
   }
 

--- a/libs/chlorophyll/scss/components/form/checkbox/_tokens.scss
+++ b/libs/chlorophyll/scss/components/form/checkbox/_tokens.scss
@@ -18,10 +18,17 @@
   @media (prefers-color-scheme: dark) {
     --gds-comp-checkbox-container-color: var(--gds-sys-color-base-container);
     --gds-comp-checkbox-border-color: transparent;
-
     --gds-comp-checkbox-hover-border-color: var(--gds-sys-color-blue);
     --gds-comp-checkbox-container-color-selected: var(--gds-sys-color-blue-dark-2);
     --gds-comp-checkbox-border-color-selected: var(--gds-ref-pallet-base000);
   }
 
+  .light {
+    --gds-comp-checkbox-container-color: var(--gds-sys-color-surface);
+    --gds-comp-checkbox-border-color: var(--gds-sys-color-base);
+    --gds-comp-checkbox-border-radius: var(--gds-sys-shape-corner-small);
+    --gds-comp-checkbox-hover-border-color: var(--gds-ref-pallet-base600);
+    --gds-comp-checkbox-container-color-selected: var(--gds-sys-color-base);
+    --gds-comp-checkbox-border-color-selected: var(--gds-sys-color-surface);
+  }
 }

--- a/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
@@ -88,18 +88,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend>Checkbox group</legend>
         <div>
-        <label class="form-control">
-          One
-          <input required type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
     </div>
@@ -142,18 +142,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           Checkbox group description
         </span>
         <div>
-        <label class="form-control">
-          One
-          <input required class="is-valid" type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required class="is-valid" type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required class="is-valid" type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required class="is-valid" type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
       <span class="form-info">Valid</span>
@@ -163,18 +163,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <legend>Invalid checkbox group</legend>
         <span class="form-info">Checkbox group description</span>
         <div>
-        <label class="form-control">
-          One
-          <input required class="is-invalid" type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required class="is-invalid" type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required class="is-invalid" type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required class="is-invalid" type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
       <span class="form-info">Error</span>
@@ -193,18 +193,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           Checkbox group description
         </span>
         <div>
-        <label class="form-control">
-          One
-          <input required type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
       <span class="form-info">Neutral</span>
@@ -216,18 +216,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           Checkbox group description
         </span>
         <div>
-        <label class="form-control">
-          One
-          <input required class="is-valid" type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required class="is-valid" type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required class="is-valid" type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required class="is-valid" type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
       <span class="form-info">Valid</span>
@@ -237,18 +237,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <legend>Invalid checkbox group</legend>
         <span class="form-info">Checkbox group description</span>
         <div>
-        <label class="form-control">
-          One
-          <input required class="is-invalid" type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required class="is-invalid" type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+          <label class="form-control">
+            One
+            <input required class="is-invalid" type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required class="is-invalid" type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
         </div>
       </fieldset>
       <span class="form-info">Error</span>

--- a/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
@@ -13,7 +13,7 @@ export const Template = ({ validation, enabled, text }) => {
 
 <Meta
   title="Components/Form/Elements/Checkbox"
-  parameters={{ 
+  parameters={{
     componentIds: ['component-checkbox']
   }}
   argTypes={{
@@ -61,18 +61,20 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
     <div class="form-group">
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend class="sr-only">Checkbox group</legend>
-        <label class="form-control">
-          One
-          <input required type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+        <div>
+          <label class="form-control">
+            One
+            <input required type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
+        </div>
       </fieldset>
     </div>
   </form>
@@ -85,6 +87,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
     <div class="form-group">
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend>Checkbox group</legend>
+        <div>
         <label class="form-control">
           One
           <input required type="checkbox" />
@@ -97,6 +100,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
     </div>
   </form>
@@ -114,18 +118,20 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <span id="checkboxGroupHelp" class="form-info">
           Checkbox group description
         </span>
-        <label class="form-control">
-          One
-          <input required type="checkbox" />
-          <span></span>
-          <i />
-        </label>
-        <label class="form-control">
-          Two
-          <input required type="checkbox" required />
-          <span></span>
-          <i />
-        </label>
+        <div>
+          <label class="form-control">
+            One
+            <input required type="checkbox" />
+            <span></span>
+            <i />
+          </label>
+          <label class="form-control">
+            Two
+            <input required type="checkbox" required />
+            <span></span>
+            <i />
+          </label>
+          </div>
       </fieldset>
       <span class="form-info">Neutral</span>
     </div>
@@ -135,6 +141,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <span id="checkboxGroupHelp1" class="form-info">
           Checkbox group description
         </span>
+        <div>
         <label class="form-control">
           One
           <input required class="is-valid" type="checkbox" />
@@ -147,6 +154,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
       <span class="form-info">Valid</span>
     </div>
@@ -154,6 +162,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
       <fieldset aria-describedby="checkboxGroupHelp2" class="is-invalid">
         <legend>Invalid checkbox group</legend>
         <span class="form-info">Checkbox group description</span>
+        <div>
         <label class="form-control">
           One
           <input required class="is-invalid" type="checkbox" />
@@ -166,6 +175,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
       <span class="form-info">Error</span>
     </div>
@@ -182,6 +192,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <span id="checkboxGroupHelp" class="form-info">
           Checkbox group description
         </span>
+        <div>
         <label class="form-control">
           One
           <input required type="checkbox" />
@@ -194,6 +205,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
       <span class="form-info">Neutral</span>
     </div>
@@ -203,6 +215,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
         <span id="checkboxGroupHelp1" class="form-info">
           Checkbox group description
         </span>
+        <div>
         <label class="form-control">
           One
           <input required class="is-valid" type="checkbox" />
@@ -215,6 +228,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
       <span class="form-info">Valid</span>
     </div>
@@ -222,6 +236,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
       <fieldset aria-describedby="checkboxGroupHelp2" class="is-invalid">
         <legend>Invalid checkbox group</legend>
         <span class="form-info">Checkbox group description</span>
+        <div>
         <label class="form-control">
           One
           <input required class="is-invalid" type="checkbox" />
@@ -234,6 +249,7 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           <span></span>
           <i />
         </label>
+        </div>
       </fieldset>
       <span class="form-info">Error</span>
     </div>

--- a/libs/chlorophyll/scss/components/form/common/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/common/_mixins.scss
@@ -30,13 +30,12 @@
     fieldset {
       @include common.margin-bottom(0);
 
-      .form-info {
-        display: inline-flex;
+      legend {
+        @include common.padding(0);
       }
 
-      label.form-control:first-of-type,
-      .label.form-control:first-of-type {
-        margin-inline-start: -1rem;
+      .form-info {
+        display: inline-flex;
       }
     }
 
@@ -89,7 +88,6 @@
 @mixin add-form-control {
   @include common.padding-vertical(4);
   @include common.padding-horizontal(5);
-  margin-inline-start: -1rem;
   border: 1px solid transparent;
   border-radius: var(--gds-sys-shape-corner-medium);
   align-items: center;

--- a/libs/chlorophyll/scss/components/form/validation/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/validation/_mixins.scss
@@ -34,8 +34,8 @@ $_border-width: var(--sg-border-width);
 }
 
 @mixin add-form-info() {
-  @include common.font-scale(2);
-  @include common.line-height(4);
+  @include common.font-scale(1);
+  @include common.line-height(3);
   color: tokens.$text-primary-color; //map-get(tokens.$grey, 3);
   max-width: fit-content;
   max-width: -moz-fit-content;
@@ -76,48 +76,35 @@ $_border-width: var(--sg-border-width);
 @mixin add-fieldset-validation() {
   fieldset {
     @include common.padding(0);
+    @include common.margin(0);
     border: 0;
     width: fit-content;
-    margin-block-start: 1.75rem;
 
-    &:has(.form-info) {
-      margin-block-start: 3rem;
+    > div {
+      @include common.margin-top(3);
+      width: fit-content;
     }
 
-    .form-info {
-      top: 1.25rem;
-      position: absolute;
+    &.is-valid > div {
+      border: $_border-width solid tokens.$intent-success-background;
+      border-radius: var(--gds-sys-shape-corner-medium);
     }
 
-    &.is-valid {
-      box-shadow: 0 0 0 $_border-width tokens.$intent-success-background;
-    }
-
-    &.is-invalid {
-      box-shadow: 0 0 0 $_border-width tokens.$intent-danger-background;
+    &.is-invalid > div {
+      border: $_border-width solid tokens.$intent-danger-background;
+      border-radius: var(--gds-sys-shape-corner-medium);
     }
   }
 
   fieldset.is-valid,
   fieldset.is-invalid {
     @include common.add-border-radius();
-    @include common.padding-start(5);
-    @include common.margin-bottom(4);
-
-    legend {
-      margin-left: -1rem;
-    }
-
-    .form-info {
-      margin-inline-start: -1rem;
-    }
+    @include common.margin-bottom(2);
   }
 
   legend {
+    @include common.padding(0);
     @include common.font-weight('medium');
-    line-height: 1.25rem;
-    padding: 0;
-    position: absolute;
-    top: 0;
+    @include common.line-height(2);
   }
 }

--- a/libs/chlorophyll/scss/tokens/_colors.scss
+++ b/libs/chlorophyll/scss/tokens/_colors.scss
@@ -34,3 +34,13 @@
     --gds-sys-color-blue-dark-2: #2c9cd9;
   }
 }
+
+.light {
+  --gds-sys-color-blue: #41b0ee;
+  --gds-sys-color-blue-dark-1: #0092e1;
+  --gds-sys-color-blue-dark-2: #007ac7;
+
+  --gds-sys-color-surface: var(--gds-ref-pallet-base000);
+  --gds-sys-color-base: var(--gds-ref-pallet-base800);
+  --gds-sys-color-base-container: var(--gds-ref-pallet-base500);
+}


### PR DESCRIPTION
The hmtl structure and styling of fieldsets were not optimal. I added a div to wrap lables/checkboxes in fieldset, this way we can have more predictable sizing. Also updated line-heights and font-sizes to match design in Figma. Also fixed some problems with tokens being dark ones but should be light. Also improved focus visuals with :has

BREAKING CHANGE: 🧨 -Breaks fieldset styling since we need to add a div to to wrap the form items.