### PR TITLE
feat: 🎸 dropdown add formControl reset functionality

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -2,16 +2,36 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
-  Component, ContentChild, ElementRef, EventEmitter, Input,
+  Component,
+  ContentChild,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  Injector,
+  Input,
   OnChanges,
   OnDestroy,
-  Output, SimpleChanges, ViewChild
+  Output,
+  SimpleChanges,
+  ViewChild,
 } from '@angular/core'
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms'
 import {
-  AbstractDropdown, CompareWith, createDropdown, DropdownArgs, DropdownHandler,
+  ControlValueAccessor,
+  NgControl,
+  NG_VALUE_ACCESSOR,
+} from '@angular/forms'
+import {
+  AbstractDropdown,
+  CompareWith,
+  createDropdown,
+  DropdownArgs,
+  DropdownHandler,
   DropdownOption,
-  DropdownOptionElement, DropdownTexts, dropdownValues, ElementProps, SearchFilter
+  DropdownOptionElement,
+  DropdownTexts,
+  dropdownValues,
+  ElementProps,
+  SearchFilter,
 } from '@sebgroup/extract'
 import { NggDropdownOptionDirective } from './dropdown-option.directive'
 
@@ -87,7 +107,14 @@ export class NggDropdownComponent
   listbox?: Partial<ElementProps> = dropdownValues.elements?.listbox
   fieldset?: Partial<ElementProps> = dropdownValues.elements?.fieldset
 
-  constructor(private cd: ChangeDetectorRef) {}
+  get control(): NgControl | undefined {
+    return this.injector.get(NgControl)
+  }
+
+  constructor(
+    private cd: ChangeDetectorRef,
+    @Inject(Injector) private injector: Injector
+  ) {}
 
   ngAfterViewInit(): void {
     if (this.togglerRef?.nativeElement && this.listboxRef?.nativeElement) {
@@ -125,6 +152,14 @@ export class NggDropdownComponent
 
   writeValue(value: any): void {
     this.value = value
+    if (
+      value === null &&
+      this.dropdown?.isTouched &&
+      this.control?.control?.untouched
+    ) {
+      this.handler?.resetTouchedState()
+      this.cd.detectChanges()
+    }
   }
 
   registerOnChange(fn: () => unknown): void {

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -13,6 +13,7 @@ import {
   validate,
   search,
   selectByValue,
+  resetTouchedProperty,
 } from './reducers'
 import { fromEvent, merge, Subject } from 'rxjs'
 import { take, takeUntil } from 'rxjs/operators'
@@ -69,6 +70,8 @@ export const createDropdown = (
   handler.update = (props) => update(handler, listener, create(props))
   handler.validate = (validator: IValidator) =>
     update(handler, listener, validate(handler.dropdown, validator))
+  handler.resetTouchedState = () =>
+    update(handler, listener, resetTouchedProperty(handler.dropdown))
 
   fromEvent(toggler, 'blur')
     .pipe(takeUntil(handler.onDestroy$))
@@ -157,7 +160,10 @@ const update = async (
     handler.onChange(handler.dropdown.value)
   }
 
-  if (oldState.isTouched !== handler.dropdown.isTouched) {
+  if (
+    handler.dropdown.isTouched &&
+    oldState.isTouched !== handler.dropdown.isTouched
+  ) {
     handler.onTouched?.()
   }
 

--- a/libs/extract/src/lib/dropdown/reducers.spec.ts
+++ b/libs/extract/src/lib/dropdown/reducers.spec.ts
@@ -10,6 +10,7 @@ import {
   loop,
   highlight,
   search,
+  resetTouchedProperty,
 } from './reducers'
 import { AbstractDropdown, DropdownOption, DropdownTexts } from './types'
 
@@ -388,6 +389,13 @@ describe('dropdown/reducers', () => {
 
         expect(dropdown.options[0].classes).not.toContain('hidden')
         expect(dropdown.options[1].classes).not.toContain('hidden')
+      })
+    })
+
+    describe('reset', () => {
+      it('resets dropdown property to false', () => {
+        dropdown = resetTouchedProperty({ ...dropdown, isTouched: true })
+        expect(dropdown.isTouched).toEqual(false)
       })
     })
   })

--- a/libs/extract/src/lib/dropdown/reducers.ts
+++ b/libs/extract/src/lib/dropdown/reducers.ts
@@ -413,3 +413,10 @@ export const search = (
         : { ...option, classes: addClass(option.classes, 'hidden') }
     }),
   } as Partial<AbstractDropdown>)
+
+export const resetTouchedProperty = (
+  dropdown: AbstractDropdown
+): AbstractDropdown =>
+  reduce(dropdown, {
+    isTouched: false,
+  } as Partial<AbstractDropdown>)

--- a/libs/extract/src/lib/dropdown/types.ts
+++ b/libs/extract/src/lib/dropdown/types.ts
@@ -110,5 +110,6 @@ export interface DropdownHandler {
   selectByValue: (selection: any) => Promise<void>
   validate: (validator: IValidator) => Promise<void>
   search: (searchInput: string) => Promise<void>
+  resetTouchedState: () => Promise<void>
   destroy: () => void
 }


### PR DESCRIPTION
reset field form control when user programatically formControl.reset() field and update touched state after user is leaving field

BREAKING CHANGE: - -

✅ Closes: 643


[issue](https://github.com/sebgroup/green/issues/643)