### PR TITLE
fix: 🐛 Usage of close in alert, badge, button, card & modal

### DIFF
--- a/libs/angular/src/lib/modal/modal.component.ts
+++ b/libs/angular/src/lib/modal/modal.component.ts
@@ -84,6 +84,7 @@ export class NggModalComponent implements OnDestroy {
     <h3 data-testid="modal-header-text">{{header}}</h3>
     <button data-testid="modal-close-button" class="close" (click)="this.handleClose($event)">
         <span className="sr-only">Close</span>
+        <i></i>
     </button>
     `
 })

--- a/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.mdx
+++ b/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.mdx
@@ -134,6 +134,7 @@ If the alert has actions like buttons or links they should be placed inside a `<
       </div>
       <button className="close">
         <span className="sr-only">Close</span>
+        <i></i>
       </button>
     </div>
     <div role="alert" className="success">
@@ -214,7 +215,7 @@ The alert should either be dismissible by a close button or a button with an act
         Alert with dismiss (close) button.
       </p>
     </div>
-    <button class="close" type="button"><span className="sr-only">Close</span></button>
+    <button class="close" type="button"><span className="sr-only">Close</span><i></i></button>
   </div>
   </div>
 </Canvas>

--- a/libs/chlorophyll/scss/components/badge/badge.stories.mdx
+++ b/libs/chlorophyll/scss/components/badge/badge.stories.mdx
@@ -7,6 +7,7 @@ export const Template = ({ variant, dismissible, text }) => {
       ${dismissible ?
         `<button class="close">
           <span class="sr-only">Remove</span>
+          <i></i>
         </button>` : ``}
     </span>`
 }
@@ -81,37 +82,44 @@ Badges that can be dismissed/removed
     <strong>Badge</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>
   </span>
   <span class="badge info">
     <strong>Information</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>  </span>
   <span class="badge success">
     <strong>Success</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>  </span>
   <span class="badge warning">
     <strong>Warning</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>  </span>
   <span class="badge danger">
     <strong>Danger</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>  </span>
   <span class="badge light">
     <strong>Light</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>  </span>
   <span class="badge dark">
     <strong>Dark</strong>
     <button type="button" class="close">
       Remove
+      <i></i>
     </button>
   </span>
   </div>

--- a/libs/chlorophyll/scss/components/button/button.stories.mdx
+++ b/libs/chlorophyll/scss/components/button/button.stories.mdx
@@ -78,6 +78,7 @@ Sizes can changed with size classes
 <Canvas>
   <button class="close">
     <span class="sr-only">Close</span>
+    <i></i>
   </button>
 </Canvas>
 

--- a/libs/chlorophyll/scss/components/card/card.stories.mdx
+++ b/libs/chlorophyll/scss/components/card/card.stories.mdx
@@ -5,7 +5,7 @@ export const Template = ({ heading,closeButton, body, button, primaryButton, lin
       ${heading || closeButton ?
       `<header>
         <h3>${heading}</h3>
-        ${closeButton ? `<button class="close" type="button"><span class="sr-only">Close</span></button>` : ''}
+        ${closeButton ? `<button class="close" type="button"><span class="sr-only">Close</span><i></i></button>` : ''}
        </header>` : ''
       }
       <p>${body}</p>
@@ -90,7 +90,7 @@ If the card has actions (like buttons) or contain links, they should be placed i
     <section class="card">
       <header>
         <h3>Heading</h3>
-        <button class="close"><span class="sr-only">Close</span></button>
+        <button class="close"><span class="sr-only">Close</span><i></i></button>
       </header>
       <p>
         Card content placed here.

--- a/libs/chlorophyll/scss/components/modal/_mixins.scss
+++ b/libs/chlorophyll/scss/components/modal/_mixins.scss
@@ -41,6 +41,7 @@ $backdrop-z-index: var(--sg-z-index-modal-backdrop);
   @include common.add-border-color();
   display: inline-flex;
   justify-content: space-between;
+  align-items: center;
   width: 100%;
 
   h3,

--- a/libs/chlorophyll/scss/components/modal/modal.stories.mdx
+++ b/libs/chlorophyll/scss/components/modal/modal.stories.mdx
@@ -18,6 +18,7 @@ export const DialogueTemplate = ({ headline, body }) => {
       <h3 id="modal_header">${headline}</h3>
       <button class='close'>
         <span class='sr-only'>Close</span>
+        <i></i>
       </button>
     </header>
     <div class='body' id="modal_body">
@@ -40,6 +41,7 @@ export const SlideoutTemplate = ({ headline, body }) => {
       <h3 id="modal_header">${headline}</h3>
       <button class='close'>
         <span class='sr-only'>Close</span>
+        <i></i>
       </button>
     </header>
     <div class='body' id="modal_body">
@@ -61,6 +63,7 @@ export const TakeoverTemplate = ({ headline, body }) => {
       <h3 id="modal_header">${headline}</h3>
       <button class='close'>
         <span class='sr-only'>Close</span>
+        <i></i>
       </button>
     </header>
     <div class='body' id="modal_body">
@@ -191,6 +194,7 @@ Content placed inside modal body, ie. element with <code>.body</code> class will
         <h3>Header</h3>
         <button class='close'>
           <span class='sr-only'>Close</span>
+          <i></i>
         </button>
       </header>
       <div class='body' id="modal_body">
@@ -216,6 +220,7 @@ Content placed inside modal body, ie. element with <code>.body</code> class will
         <h3>Header</h3>
         <button class='close'>
           <span class='sr-only'>Close</span>
+          <i></i>
         </button>
       </header>
       <div class='body' id="modal_body">

--- a/libs/react/src/lib/alert/alert.tsx
+++ b/libs/react/src/lib/alert/alert.tsx
@@ -26,11 +26,17 @@ export function Alert({
     } else {
       if (closeText)
         setCloseButton(
-          <Button variant="ghost">
+          <button className="close">
             <span className="sr-only">{closeText}</span>
-          </Button>
+            <i></i>
+          </button>
         )
-      else setCloseButton(<button className="close" />)
+      else setCloseButton(
+        <button className="close">
+              <span className="sr-only">Close</span>
+              <i></i>
+        </button>
+      )
     }
   }, [isCloseable, closeText])
 

--- a/libs/react/src/lib/badge/badge.tsx
+++ b/libs/react/src/lib/badge/badge.tsx
@@ -49,6 +49,7 @@ export function Badge({
           onClick={() => setIsClosed(true)}
         >
           {closeText}
+          <i></i>
         </button>
       )}
     </span>

--- a/libs/react/src/lib/card/card.stories.mdx
+++ b/libs/react/src/lib/card/card.stories.mdx
@@ -12,6 +12,7 @@ export const Header = () => (
     <h3>Card Headline</h3>
     <Button variant="close">
       <span className="sr-only">Close</span>
+      <i></i>
     </Button>
   </>
 )

--- a/libs/react/src/lib/form/button/button.stories.mdx
+++ b/libs/react/src/lib/form/button/button.stories.mdx
@@ -49,6 +49,7 @@ Close button with text for screen readers
 <Canvas>
   <Button variant="close">
     <span className="sr-only">Close</span>
+    <i></i>
   </Button>
 </Canvas>
 

--- a/libs/react/src/lib/modal/modal.tsx
+++ b/libs/react/src/lib/modal/modal.tsx
@@ -27,6 +27,7 @@ const ModalHeader = ({ header = '', onClose }: Partial<ModalProps>) => {
       <h3>{header}</h3>
       <button className="close" onClick={handleClose}>
         <span className="sr-only">Close</span>
+        <i></i>
       </button>
     </div>
   )


### PR DESCRIPTION
Fixed usage of close button in alert, badge, button, card and modal.

**Issues left**
- Looks strange when you press the close button on badges and also the close button is barely visible on dark badges since its black.
- The alert component for react looks broken, so the placement of the close button is not correct.