### PR TITLE
fix: 🐛 dropdown formControl reset functionality

### DIFF
--- a/libs/angular/src/lib/dropdown/documentation.mdx
+++ b/libs/angular/src/lib/dropdown/documentation.mdx
@@ -228,3 +228,51 @@ Below is an example of how the component can be used with reactive forms and val
   </button>
 </form>
 ```
+
+## Example usage in reactive form with reset functionality
+
+Below is an example of reset functionality for dropdown
+
+<Story id="components-dropdown--form-with-reset" />
+
+### Markup
+
+```html
+<form
+  [formGroup]="validationFormAdvance"
+  #ngForm="ngForm"
+  (submit)="save(validationFormAdvance.value)"
+>
+  <div
+    class="form-group"
+    *ngIf="validationFormAdvance.get('country') as dropdown"
+  >
+    <ngg-dropdown
+      label="Country"
+      [options]="options$ | async"
+      formControlName="country"
+      [valid]="dropdown.valid && ngForm.submitted"
+      [invalid]="dropdown.invalid && ngForm.submitted"
+    >
+      <!-- Hint text when not submitted -->
+      <ng-container data-form-info *ngIf="!ngForm['submitted']"
+        >Select country</ng-container
+      >
+      <ng-container data-form-info *ngIf="ngForm['submitted']">
+        <!-- Text when form control contains one or more errors -->
+        <ng-container *ngIf="dropdown.errors as errors">
+          <!-- Text for each error (only one will be displayed at a time) -->
+          <ng-container *ngIf="errors['required']">Select country</ng-container>
+        </ng-container>
+      </ng-container>
+    </ngg-dropdown>
+  </div>
+  <button
+    type="submit"
+    [disabled]="ngForm?.submitted && validationFormAdvance.invalid"
+  >
+    Save
+  </button>
+  <button (click)="validationFormAdvance.reset()">Reset</button>
+</form>
+```

--- a/libs/angular/src/lib/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.stories.ts
@@ -227,7 +227,7 @@ const FormControlTemplate: Story<NggDropdownComponent> = (
       value: 'netherlands',
     },
     {
-      klabeley: 'Belgium',
+      label: 'Belgium',
       value: 'belgium',
     },
     {
@@ -292,3 +292,68 @@ const FormControlTemplate: Story<NggDropdownComponent> = (
 
 export const Form = FormControlTemplate.bind({})
 Form.args = {}
+
+const FormControlWithResetTemplate: Story<NggDropdownComponent> = (
+  args: NggDropdownComponent
+) => {
+  const validationFormAdvance = new FormGroup({
+    country: new FormControl(undefined, [Validators.required]),
+  })
+
+  const options$ = of([
+    {
+      label: 'Sweden',
+      value: { country: 'sweden', id: '1' },
+    },
+    {
+      label: 'Australia',
+      value: { country: 'Australia', id: '2' },
+    },
+  ]).pipe(delay(3000))
+
+  const save = (form: any) => {
+    console.log('Saved!', form)
+  }
+
+  return {
+    component: NggDropdownComponent,
+    template: `
+    <form [formGroup]="validationFormAdvance" #ngForm="ngForm" (submit)="save(validationFormAdvance.value)">
+    <div class="form-group" *ngIf="validationFormAdvance.get('country') as dropdown">
+      <ngg-dropdown
+        label="Country"
+        [options]="options$ | async"
+        formControlName="country"
+        [invalid]="validationFormAdvance.get('country').invalid && validationFormAdvance.get('country').touched"
+      >
+        <!-- Hint text when not submitted -->
+        <ng-container data-form-info *ngIf="!ngForm['submitted']"
+          >Select country</ng-container
+        >
+        <ng-container data-form-info *ngIf="ngForm['submitted']">
+          <!-- Text when form control contains one or more errors -->
+          <ng-container *ngIf="dropdown.errors as errors">
+            <!-- Text for each error (only one will be displayed at a time) -->
+            <ng-container *ngIf="errors['required']">Select country</ng-container>
+          </ng-container>
+        </ng-container>
+      </ngg-dropdown>
+    </div>
+    <button type="submit" [disabled]="ngForm?.submitted && validationFormAdvance.invalid">
+      Save
+    </button>
+    <button (click)="validationFormAdvance.reset()">
+    Reset
+    </button>
+    `,
+    props: {
+      ...args,
+      validationFormAdvance,
+      options$,
+      save,
+    },
+  }
+}
+
+export const FormWithReset = FormControlWithResetTemplate.bind({})
+FormWithReset.args = {}

--- a/libs/extract/src/lib/dropdown/reducers.ts
+++ b/libs/extract/src/lib/dropdown/reducers.ts
@@ -90,7 +90,7 @@ export const create = ({
     },
     elements: {
       toggler: {
-        attributes: { id: `${id}_toggle`, 'aria-owns': id},
+        attributes: { id: `${id}_toggle`, 'aria-owns': id },
       },
       listbox: {
         attributes: { id },
@@ -283,7 +283,12 @@ export const selectByValue = (
     options,
   })
 
-  return { ...newDropdown, value: selection }
+  // reset (null) value does not override previous value in the reduce function
+  if (selection === null) {
+    newDropdown.value = null
+  }
+
+  return newDropdown
 }
 
 /**

--- a/libs/extract/src/lib/dropdown/reducers.ts
+++ b/libs/extract/src/lib/dropdown/reducers.ts
@@ -253,7 +253,7 @@ export const selectByValue = (
 
   if (selection && dropdown.isMultiSelect && !Array.isArray(selection)) {
     console.warn(
-      'Dropdown is marked as multiselect but recieved a non-array value:',
+      'Dropdown is marked as multiselect but received a non-array value:',
       selection
     )
   }
@@ -268,8 +268,7 @@ export const selectByValue = (
     })
   })
   const selectedOptions = options.filter((o) => o.selected)
-
-  return reduce(dropdown, {
+  const newDropdown = reduce(dropdown, {
     value: selection,
     texts: {
       select: selectionText(selectedOptions, dropdown.display, dropdown.texts),
@@ -283,6 +282,8 @@ export const selectByValue = (
     },
     options,
   })
+
+  return { ...newDropdown, value: selection }
 }
 
 /**


### PR DESCRIPTION
When the user tries to reset the form, it will not work properly if the dropdown options value contain more than one field.

BREAKING CHANGE: 🧨 --

✅ Closes: #690
