### PR TITLE
fix: 🐛 reorder stories

### DIFF
--- a/libs/react/.storybook/main.js
+++ b/libs/react/.storybook/main.js
@@ -6,8 +6,8 @@ module.exports = {
   core: { ...rootMain.core, builder: 'webpack5' },
   stories: [
     ...rootMain.stories,
-    '../src/lib/**/*.stories.mdx',
     '../src/introduction/**/*.stories.mdx',
+    '../src/lib/**/*.stories.mdx',
     '../src/lib/**/*.stories.@(js|jsx|ts|tsx)',
   ],
   addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],


### PR DESCRIPTION
Reorder stories so that the default page on load of the React Storybook would be the Introduction page.