### PR TITLE
test: 💍 fix failing unit test in react datepicker

### DIFF
--- a/libs/react/src/lib/datepicker/datepicker.spec.tsx
+++ b/libs/react/src/lib/datepicker/datepicker.spec.tsx
@@ -6,6 +6,8 @@ import { Datepicker } from './datepicker'
 
 const tick = (ms?: number) => new Promise<void>((r) => setTimeout(r, ms || 0))
 
+const pad = (num: number): string => `${num < 10 ? '0' : ''}${num}`
+
 describe('Datepicker', () => {
   it('renders', async () => {
     const component = render(<Datepicker />)
@@ -86,13 +88,11 @@ describe('Datepicker', () => {
       await act(() => user.click(button))
 
       const _15th = await findByText('15')
-      user.click(_15th)
-      
-      const calendar = await findByRole('dialog')
+      user.click(_15th)      
       await act(() => tick())
 
       const todaysDate = new Date()
-      const expectedDate = `${todaysDate.getUTCFullYear()}-${todaysDate.getUTCMonth()+1}-15`
+      const expectedDate = `${todaysDate.getUTCFullYear()}-${pad(todaysDate.getUTCMonth()+1)}-15`
       expect(onChangeMock).toBeCalledTimes(1)
       expect(onChangeMock).toBeCalledWith(expectedDate);
     })


### PR DESCRIPTION
New function created to add leading zeroes to month values to fix below failing unit test case:

![image](https://user-images.githubusercontent.com/82629695/211731530-5b913864-62f8-419a-991e-a7d52de4ce3a.png)
