### PR TITLE
fix: 🐛 not updated dropdown translations on texts input change fix

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -144,8 +144,9 @@ export class NggDropdownComponent
   ngOnChanges(changes: SimpleChanges): void {
     if (
       this.handler &&
-      (changes.id || changes.text || changes.loop || changes.options)
+      (changes.id || changes.texts || changes.loop || changes.options)
     ) {
+      
       this.handler.update(this.props)
     }
   }


### PR DESCRIPTION
Allow to change dropdown translation then language is changing

BREAKING CHANGE:  -

✅ Closes: -