### PR TITLE
fix(slide-toggle): 🐛 move transition to hover

### DIFF
--- a/libs/chlorophyll/scss/components/slide-toggle/_mixins.scss
+++ b/libs/chlorophyll/scss/components/slide-toggle/_mixins.scss
@@ -10,6 +10,7 @@ $_track_height: 1.5rem;
 $_track_width: 2.75rem;
 $_track_height_mobile: 2rem;
 $_track_width_mobile: 3.5rem;
+$_track_transition_time: 150ms;
 $_track_color: var(--sg-grey-400);
 $_track_color_hover: var(--sg-grey-500);
 $_track_color_pressed: hsl(var(--sg-hsl-green-1));
@@ -17,6 +18,7 @@ $_track_color_pressed_hover: hsl(var(--sg-hsl-green-2));
 
 $_thumb_width: 1.25rem;
 $_thumb_width_mobile: 1.75rem;
+$_thumb_transition_time: 300ms;
 $_thumb_hover_nudge: .25rem;
 $_thumb_color: white;
 
@@ -34,7 +36,6 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
   appearance: none;
   background: $_track_color;
   text-align: left;
-  transition: 150ms;
   vertical-align: sub;
 
   // Thumb
@@ -45,7 +46,6 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
     height: 100%;
     border-radius: 100%;
     aspect-ratio: 1;
-    transition: 300ms;
     box-shadow:
       0 2px 8px 0 rgba(0,0,0,0.15),
       0 1px 2px 0 rgba(0,0,0,0.15),
@@ -55,9 +55,11 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
   @media (hover: hover) { 
     &:hover {
       background-color: $_track_color_hover;
+      transition: $_track_transition_time;
     }
     &:hover::after {
       transform: translateX($_thumb_hover_nudge);
+      transition: $_thumb_transition_time;
     }
   }
 
@@ -81,9 +83,11 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
   @media (hover: hover) { 
     &:hover {
       background-color: $_track_color_pressed_hover;
+      transition: $_track_transition_time;
     }
     &:hover::after {
-    transform: translateX($thumb_pressed_translateX - $_thumb_hover_nudge);
+      transform: translateX($thumb_pressed_translateX - $_thumb_hover_nudge);
+      transition: $_thumb_transition_time;
     }
   }
 
@@ -94,6 +98,7 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
     @media (hover: hover) {
       &:hover::after {
         transform: translateX($thumb_pressed_translateX_mobile - $_thumb_hover_nudge);
+        transition: $_thumb_transition_time;
       }
     } 
   }


### PR DESCRIPTION
The transition being set directly in the mixin caused some awkward visual effects when using e.g. `visibility: hidden` on a parent element. Moving the transition styling to appear only on hover effect (which is the intended use of it), keeps the visual transition effect when needed, but does not give awkward visual effects when using `visibility:hidden`.

To reproduce:

- go to [storybook: slide-toggle](https://sebgroup.github.io/green/latest/chlorophyll/?path=/docs/components-slide-toggle--slide-toggle)
- open dev tools and apply `visibility:hidden;` on a parent element to the slide-toggle button
- watch how it disappears from the view with an awkward transition

The new code will only apply the transition when hovering and you can toggle the visibility of a parent element as much as you want.