### PR TITLE
docs(chlorophyll): change `className` to `class` in examples

### DIFF
--- a/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.mdx
+++ b/libs/chlorophyll/scss/components/alert-ribbon/alert-ribbon.stories.mdx
@@ -9,27 +9,35 @@ export const Template = ({
   primaryButton,
   closeButton,
 }) => `
-  <div role="alert" className="${type}">
+  <div role="alert" class="${type}">
     <i>
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM12 7.07143C12.8284 7.07143 13.5 7.743 13.5 8.57143C13.5 9.39986 12.8284 10.0714 12 10.0714C11.1716 10.0714 10.5 9.39986 10.5 8.57143C10.5 7.743 11.1716 7.07143 12 7.07143ZM14 16.1429C14 16.3795 13.8081 16.5714 13.5714 16.5714H10.4286C10.1919 16.5714 10 16.3795 10 16.1429V15.2857C10 15.049 10.1919 14.8571 10.4286 14.8571H10.8571V12.5714H10.4286C10.1919 12.5714 10 12.3795 10 12.1429V11.2857C10 11.049 10.1919 10.8571 10.4286 10.8571H12.7143C12.951 10.8571 13.1429 11.049 13.1429 11.2857V14.8571H13.5714C13.8081 14.8571 14 15.049 14 15.2857V16.1429Z" fill="#333333"/>
       </svg>
     </i>
     <div>
-      ${heading ?
-        `<h3>${heading}</h3>` : ''
-      }
+      ${heading ? `<h3>${heading}</h3>` : ''}
       <p>
         ${content}
         ${link ? `<a href="#">${link}</a>.` : ''}
       </p>
     </div>
-    ${closeButton ? `<button class="close" type="button"><span className="sr-only">Close</span><i></i></button>` : ''}
-    ${button || primaryButton  ?
-    `<footer>
+    ${
+      closeButton
+        ? `<button class="close" type="button"><span class="sr-only">Close</span><i></i></button>`
+        : ''
+    }
+    ${
+      button || primaryButton
+        ? `<footer>
         ${button ? `<button type="button">${button}</button>` : ''}
-        ${primaryButton ? `<button type="button" className="primary">${primaryButton}</button>` : ''}
-     </footer>` : ''
+        ${
+          primaryButton
+            ? `<button type="button" class="primary">${primaryButton}</button>`
+            : ''
+        }
+     </footer>`
+        : ''
     }
   </div>
 `
@@ -37,7 +45,7 @@ export const Template = ({
 <Meta
   title="Components/Alert ribbon"
   parameters={{
-    componentIds: ['component-alertribbon']
+    componentIds: ['component-alertribbon'],
   }}
   argTypes={{
     type: {
@@ -53,7 +61,8 @@ export const Template = ({
   }}
 />
 
-<style>{`
+<style>
+  {`
   [role="alert"] + [role="alert"] {
     margin-top: 1.5rem;
   }`}
@@ -62,21 +71,22 @@ export const Template = ({
 # Alert ribbon
 
 <Story
-    name="Alert ribbon"
-    args={{
-      type: '',
-      heading: 'Can contain a heading.',
-      content: 'Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or',
-      link: 'part of the sentence.',
-      button: false,
-      primaryButton: '',
-      closeButton: true
-    }}
-  >
-    {Template.bind({})}
+  name="Alert ribbon"
+  args={{
+    type: '',
+    heading: 'Can contain a heading.',
+    content:
+      'Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or',
+    link: 'part of the sentence.',
+    button: false,
+    primaryButton: '',
+    closeButton: true,
+  }}
+>
+  {Template.bind({})}
 </Story>
 
-<br/>
+<br />
 
 ## Variants
 
@@ -88,17 +98,17 @@ An alert ribbon is a message used to inform the user about the state of a system
       <p>Neutral (no class)</p>
     </div>
   </div>
-  <div role="alert" className="success">
+  <div role="alert" class="success">
     <div>
       <p>Success</p>
     </div>
   </div>
-  <div role="alert" className="warning">
+  <div role="alert" class="warning">
     <div>
       <p>Warning</p>
     </div>
   </div>
-  <div role="alert" className="danger">
+  <div role="alert" class="danger">
     <div>
       <p>Danger</p>
     </div>
@@ -113,7 +123,7 @@ Alerts can contain the following elements:
 Content should be placed inside `<div>...</div>` and may in turn contain a heading `<h1>, <h2>, <h3>, <h4>, <h5>` and a `<p>` with additional content like links etc.
 
 **Close button**<br/>
-`<button className="close">...</button>` if the alert is dismissible.
+`<button class="close">...</button>` if the alert is dismissible.
 
 **Footer** (optional)<br/>
 If the alert has actions like buttons or links they should be placed inside a `<footer>...</footer>`.
@@ -123,62 +133,100 @@ If the alert has actions like buttons or links they should be placed inside a `<
     <div role="alert">
       <i>
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM12 7.07143C12.8284 7.07143 13.5 7.743 13.5 8.57143C13.5 9.39986 12.8284 10.0714 12 10.0714C11.1716 10.0714 10.5 9.39986 10.5 8.57143C10.5 7.743 11.1716 7.07143 12 7.07143ZM14 16.1429C14 16.3795 13.8081 16.5714 13.5714 16.5714H10.4286C10.1919 16.5714 10 16.3795 10 16.1429V15.2857C10 15.049 10.1919 14.8571 10.4286 14.8571H10.8571V12.5714H10.4286C10.1919 12.5714 10 12.3795 10 12.1429V11.2857C10 11.049 10.1919 10.8571 10.4286 10.8571H12.7143C12.951 10.8571 13.1429 11.049 13.1429 11.2857V14.8571H13.5714C13.8081 14.8571 14 15.049 14 15.2857V16.1429Z" fill="#333333"/>
+          <path
+            d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM12 7.07143C12.8284 7.07143 13.5 7.743 13.5 8.57143C13.5 9.39986 12.8284 10.0714 12 10.0714C11.1716 10.0714 10.5 9.39986 10.5 8.57143C10.5 7.743 11.1716 7.07143 12 7.07143ZM14 16.1429C14 16.3795 13.8081 16.5714 13.5714 16.5714H10.4286C10.1919 16.5714 10 16.3795 10 16.1429V15.2857C10 15.049 10.1919 14.8571 10.4286 14.8571H10.8571V12.5714H10.4286C10.1919 12.5714 10 12.3795 10 12.1429V11.2857C10 11.049 10.1919 10.8571 10.4286 10.8571H12.7143C12.951 10.8571 13.1429 11.049 13.1429 11.2857V14.8571H13.5714C13.8081 14.8571 14 15.049 14 15.2857V16.1429Z"
+            fill="#333333"
+          />
         </svg>
       </i>
       <div>
         <h3>Can contain a heading.</h3>
         <p>
-          Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or <a href="#">part of the sentence.</a>
+          Body text starts on the same row as heading. A link (optional) always
+          ends the message, stand alone or <a href="#">part of the sentence.</a>
         </p>
       </div>
-      <button className="close">
-        <span className="sr-only">Close</span>
+      <button class="close">
+        <span class="sr-only">Close</span>
         <i></i>
       </button>
     </div>
-    <div role="alert" className="success">
+    <div role="alert" class="success">
       <i>
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M17.6203 6.60836L9.40014 14.8285L6.37976 11.8081C6.23332 11.6617 5.99588 11.6617 5.84942 11.8081L4.96554 12.692C4.8191 12.8384 4.8191 13.0759 4.96554 13.2223L9.13495 17.3917C9.28138 17.5382 9.51882 17.5382 9.66529 17.3917L19.0344 8.02258C19.1809 7.87614 19.1809 7.63871 19.0344 7.49224L18.1506 6.60836C18.0041 6.46193 17.7667 6.46193 17.6203 6.60836Z" fill="white"/>
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M17.6203 6.60836L9.40014 14.8285L6.37976 11.8081C6.23332 11.6617 5.99588 11.6617 5.84942 11.8081L4.96554 12.692C4.8191 12.8384 4.8191 13.0759 4.96554 13.2223L9.13495 17.3917C9.28138 17.5382 9.51882 17.5382 9.66529 17.3917L19.0344 8.02258C19.1809 7.87614 19.1809 7.63871 19.0344 7.49224L18.1506 6.60836C18.0041 6.46193 17.7667 6.46193 17.6203 6.60836Z"
+            fill="white"
+          />
         </svg>
       </i>
-      <div className="alert-ribbon__content">
+      <div class="alert-ribbon__content">
         <h3>Can contain a heading.</h3>
         <p>
-          Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or <a href="#">part of the sentence.</a>
+          Body text starts on the same row as heading. A link (optional) always
+          ends the message, stand alone or <a href="#">part of the sentence.</a>
         </p>
       </div>
-      <div className="alert-ribbon__footer">
+      <div class="alert-ribbon__footer">
         <button>Button</button>
       </div>
     </div>
-    <div role="alert" className="warning">
+    <div role="alert" class="warning">
       <i>
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-          <path fillRule="evenodd" clipRule="evenodd" d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM10.8682 7.42857H13.1318C13.3777 7.42857 13.5731 7.635 13.5597 7.8805L13.2948 12.7376C13.2824 12.9649 13.0945 13.1429 12.8669 13.1429H11.1331C10.9055 13.1429 10.7176 12.9649 10.7052 12.7376L10.4402 7.8805C10.4269 7.635 10.6223 7.42857 10.8682 7.42857ZM12 17.0714C11.0927 17.0714 10.3571 16.3359 10.3571 15.4286C10.3571 14.5213 11.0927 13.7857 12 13.7857C12.9073 13.7857 13.6429 14.5213 13.6429 15.4286C13.6429 16.3359 12.9073 17.0714 12 17.0714Z" fill="#333333"/>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM10.8682 7.42857H13.1318C13.3777 7.42857 13.5731 7.635 13.5597 7.8805L13.2948 12.7376C13.2824 12.9649 13.0945 13.1429 12.8669 13.1429H11.1331C10.9055 13.1429 10.7176 12.9649 10.7052 12.7376L10.4402 7.8805C10.4269 7.635 10.6223 7.42857 10.8682 7.42857ZM12 17.0714C11.0927 17.0714 10.3571 16.3359 10.3571 15.4286C10.3571 14.5213 11.0927 13.7857 12 13.7857C12.9073 13.7857 13.6429 14.5213 13.6429 15.4286C13.6429 16.3359 12.9073 17.0714 12 17.0714Z"
+            fill="#333333"
+          />
         </svg>
       </i>
       <div>
         <h3>Can contain a heading.</h3>
         <p>
-          Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or <a href="#">part of the sentence.</a>
+          Body text starts on the same row as heading. A link (optional) always
+          ends the message, stand alone or <a href="#">part of the sentence.</a>
         </p>
       </div>
       <footer>
         <button>Button</button>
       </footer>
     </div>
-    <div role="alert" className="danger">
+    <div role="alert" class="danger">
       <i>
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-        <path fillRule="evenodd" clipRule="evenodd" d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM10.8682 7.42857H13.1318C13.3777 7.42857 13.5731 7.635 13.5597 7.8805L13.2948 12.7376C13.2824 12.9649 13.0945 13.1429 12.8669 13.1429H11.1331C10.9055 13.1429 10.7176 12.9649 10.7052 12.7376L10.4402 7.8805C10.4269 7.635 10.6223 7.42857 10.8682 7.42857ZM12 17.0714C11.0927 17.0714 10.3571 16.3359 10.3571 15.4286C10.3571 14.5213 11.0927 13.7857 12 13.7857C12.9073 13.7857 13.6429 14.5213 13.6429 15.4286C13.6429 16.3359 12.9073 17.0714 12 17.0714Z" fill="#333333"/>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M18.2857 4H5.71429C4.7675 4 4 4.7675 4 5.71429V18.2857C4 19.2325 4.7675 20 5.71429 20H18.2857C19.2325 20 20 19.2325 20 18.2857V5.71429C20 4.7675 19.2325 4 18.2857 4ZM10.8682 7.42857H13.1318C13.3777 7.42857 13.5731 7.635 13.5597 7.8805L13.2948 12.7376C13.2824 12.9649 13.0945 13.1429 12.8669 13.1429H11.1331C10.9055 13.1429 10.7176 12.9649 10.7052 12.7376L10.4402 7.8805C10.4269 7.635 10.6223 7.42857 10.8682 7.42857ZM12 17.0714C11.0927 17.0714 10.3571 16.3359 10.3571 15.4286C10.3571 14.5213 11.0927 13.7857 12 13.7857C12.9073 13.7857 13.6429 14.5213 13.6429 15.4286C13.6429 16.3359 12.9073 17.0714 12 17.0714Z"
+            fill="#333333"
+          />
         </svg>
       </i>
       <div>
         <h3>Can contain a heading.</h3>
         <p>
-          Body text starts on the same row as heading. A link (optional) always ends the message, stand alone or <a href="#">part of the sentence.</a>
+          Body text starts on the same row as heading. A link (optional) always
+          ends the message, stand alone or <a href="#">part of the sentence.</a>
         </p>
       </div>
       <footer>
@@ -194,28 +242,30 @@ The alert should either be dismissible by a close button or a button with an act
 
 <Canvas>
   <div>
-  <div role="alert" className="warning">
-    <div>
-      <h3>Warning!</h3>
-      <p>
-        Alert with single action in footer and no dismiss (close) button.<br/>
-        Foo bar warning alert lorem ipsum dolar sit amet.
-      </p>
+    <div role="alert" class="warning">
+      <div>
+        <h3>Warning!</h3>
+        <p>
+          Alert with single action in footer and no dismiss (close) button.
+          <br />
+          Foo bar warning alert lorem ipsum dolar sit amet.
+        </p>
+      </div>
+      <footer>
+        <button type="button">Action</button>
+      </footer>
     </div>
-    <footer>
-      <button type="button">Action</button>
-    </footer>
-  </div>
-  <br />
-  <br />
-  <div role="alert">
-    <div>
-      <h3>Neutral</h3>
-      <p>
-        Alert with dismiss (close) button.
-      </p>
+    <br />
+    <br />
+    <div role="alert">
+      <div>
+        <h3>Neutral</h3>
+        <p>Alert with dismiss (close) button.</p>
+      </div>
+      <button class="close" type="button">
+        <span class="sr-only">Close</span>
+        <i></i>
+      </button>
     </div>
-    <button class="close" type="button"><span className="sr-only">Close</span><i></i></button>
-  </div>
   </div>
 </Canvas>

--- a/libs/chlorophyll/scss/components/close/close.stories.mdx
+++ b/libs/chlorophyll/scss/components/close/close.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 export const Template = () => {
   return `
     <button class="close" type="button">
-      <span className="sr-only">Close</span>
+      <span class="sr-only">Close</span>
       <i></i>
     </button>
   `
@@ -12,9 +12,8 @@ export const Template = () => {
 <Meta
   title="Components/Close button"
   parameters={{
-    componentIds: ['component-close-button']
-  }} />
+    componentIds: ['component-close-button'],
+  }}
+/>
 
-<Story name="Close button">
-  {Template.bind({})}
-</Story>
+<Story name="Close button">{Template.bind({})}</Story>

--- a/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/checkbox/checkbox.stories.mdx
@@ -1,6 +1,12 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks'
 
-export const Template = ({ validation, enabled, checked, indeterminate, text }) => {
+export const Template = ({
+  validation,
+  enabled,
+  checked,
+  indeterminate,
+  text,
+}) => {
   const attrValidation = validation ? `class="${validation}" ` : ``
   const attrEnabled = enabled ? `` : `disabled`
   const attrChecked = checked ? `checked` : ``
@@ -18,7 +24,7 @@ export const Template = ({ validation, enabled, checked, indeterminate, text }) 
 <Meta
   title="Components/Form/Elements/Checkbox"
   parameters={{
-    componentIds: ['component-checkbox']
+    componentIds: ['component-checkbox'],
   }}
   argTypes={{
     validation: {
@@ -26,16 +32,17 @@ export const Template = ({ validation, enabled, checked, indeterminate, text }) 
       options: ['', 'is-valid', 'is-invalid'],
     },
     enabled: {
-      control: 'boolean'
+      control: 'boolean',
     },
     checked: {
-      control: 'boolean'
+      control: 'boolean',
     },
     indeterminate: {
-      control: 'boolean'
+      control: 'boolean',
     },
     text: { control: 'text' },
-  }} />
+  }}
+/>
 
 <Story
   name="Checkbox"
@@ -43,9 +50,9 @@ export const Template = ({ validation, enabled, checked, indeterminate, text }) 
     text: 'Click me!',
     enabled: true,
     checked: false,
-    indeterminate: false
+    indeterminate: false,
   }}
-  parameters={{ docs: { disable: true }}}
+  parameters={{ docs: { disable: true } }}
 >
   {Template.bind({})}
 </Story>
@@ -57,8 +64,8 @@ Lorem ipsum checkboxes
 ## Default checkbox
 
 <Canvas>
-  <div className="form-group">
-    <label className="form-control">
+  <div class="form-group">
+    <label class="form-control">
       <input type="checkbox" />
       <span>Checkbox</span>
       <i></i>
@@ -69,33 +76,35 @@ Lorem ipsum checkboxes
 ## Invalid checkbox
 
 <Canvas>
-  <div className="form-group">
-    <label className="form-control was-validated is-invalid">
-      <input type="checkbox" className="is-invalid" />
+  <div class="form-group">
+    <label class="form-control was-validated is-invalid">
+      <input type="checkbox" class="is-invalid" />
       <span>Checkbox</span>
       <i></i>
     </label>
-    <span className="form-info">Error</span>
+    <span class="form-info">Error</span>
   </div>
 </Canvas>
 
 ## Group
+
 Group form controls such as checkboxes and radio buttons using `<fieldset>` and add an optional description using a `<legend>`.
 
 ### Default group with hidden legend
+
 <Canvas>
   <form>
-    <div className="form-group">
+    <div class="form-group">
       <fieldset aria-describedby="checkboxGroupHelp">
-        <legend className="sr-only">Checkbox group</legend>
+        <legend class="sr-only">Checkbox group</legend>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
             <input required type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
             <input required type="checkbox" required />
             <span></span>
@@ -110,18 +119,18 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
 ### Horizontal form with group and visible legend
 
 <Canvas>
-  <form className="horizontal">
-    <div className="form-group">
+  <form class="horizontal">
+    <div class="form-group">
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend>Checkbox group</legend>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
             <input required type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
             <input required type="checkbox" required />
             <span></span>
@@ -139,72 +148,72 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
 
 <Canvas>
   <form>
-    <div className="form-group was-validated">
+    <div class="form-group was-validated">
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend>Checkbox group</legend>
-        <span id="checkboxGroupHelp" className="form-info">
+        <span id="checkboxGroupHelp" class="form-info">
           Checkbox group description
         </span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
             <input required type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
             <input required type="checkbox" required />
             <span></span>
             <i></i>
           </label>
-          </div>
+        </div>
       </fieldset>
-      <span className="form-info">Neutral</span>
+      <span class="form-info">Neutral</span>
     </div>
-    <div className="form-group was-validated">
-      <fieldset aria-describedby="checkboxGroupHelp1" className="is-valid">
+    <div class="form-group was-validated">
+      <fieldset aria-describedby="checkboxGroupHelp1" class="is-valid">
         <legend>Valid checkbox group</legend>
-        <span id="checkboxGroupHelp1" className="form-info">
+        <span id="checkboxGroupHelp1" class="form-info">
           Checkbox group description
         </span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
-            <input required className="is-valid" type="checkbox" />
+            <input required class="is-valid" type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
-            <input required className="is-valid" type="checkbox" required />
+            <input required class="is-valid" type="checkbox" required />
             <span></span>
             <i></i>
           </label>
         </div>
       </fieldset>
-      <span className="form-info">Valid</span>
+      <span class="form-info">Valid</span>
     </div>
-    <div className="form-group">
-      <fieldset aria-describedby="checkboxGroupHelp2" className="is-invalid">
+    <div class="form-group">
+      <fieldset aria-describedby="checkboxGroupHelp2" class="is-invalid">
         <legend>Invalid checkbox group</legend>
-        <span className="form-info">Checkbox group description</span>
+        <span class="form-info">Checkbox group description</span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
-            <input required className="is-invalid" type="checkbox" />
+            <input required class="is-invalid" type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
-            <input required className="is-invalid" type="checkbox" required />
+            <input required class="is-invalid" type="checkbox" required />
             <span></span>
             <i></i>
           </label>
         </div>
       </fieldset>
-      <span className="form-info">Error</span>
+      <span class="form-info">Error</span>
     </div>
   </form>
 </Canvas>
@@ -212,21 +221,21 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
 ### Horizontal
 
 <Canvas>
-  <form className="horizontal">
-    <div className="form-group">
+  <form class="horizontal">
+    <div class="form-group">
       <fieldset aria-describedby="checkboxGroupHelp">
         <legend>Checkbox group</legend>
-        <span id="checkboxGroupHelp" className="form-info">
+        <span id="checkboxGroupHelp" class="form-info">
           Checkbox group description
         </span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
             <input required type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
             <input required type="checkbox" required />
             <span></span>
@@ -234,51 +243,51 @@ Group form controls such as checkboxes and radio buttons using `<fieldset>` and 
           </label>
         </div>
       </fieldset>
-      <span className="form-info">Neutral</span>
+      <span class="form-info">Neutral</span>
     </div>
-    <div className="form-group was-validated">
-      <fieldset aria-describedby="checkboxGroupHelp1" className="is-valid">
+    <div class="form-group was-validated">
+      <fieldset aria-describedby="checkboxGroupHelp1" class="is-valid">
         <legend>Valid checkbox group</legend>
-        <span id="checkboxGroupHelp1" className="form-info">
+        <span id="checkboxGroupHelp1" class="form-info">
           Checkbox group description
         </span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
-            <input required className="is-valid" type="checkbox" />
+            <input required class="is-valid" type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
-            <input required className="is-valid" type="checkbox" required />
+            <input required class="is-valid" type="checkbox" required />
             <span></span>
             <i></i>
           </label>
         </div>
       </fieldset>
-      <span className="form-info">Valid</span>
+      <span class="form-info">Valid</span>
     </div>
-    <div className="form-group was-validated">
-      <fieldset aria-describedby="checkboxGroupHelp2" className="is-invalid">
+    <div class="form-group was-validated">
+      <fieldset aria-describedby="checkboxGroupHelp2" class="is-invalid">
         <legend>Invalid checkbox group</legend>
-        <span className="form-info">Checkbox group description</span>
+        <span class="form-info">Checkbox group description</span>
         <div>
-          <label className="form-control">
+          <label class="form-control">
             One
-            <input required className="is-invalid" type="checkbox" />
+            <input required class="is-invalid" type="checkbox" />
             <span></span>
             <i></i>
           </label>
-          <label className="form-control">
+          <label class="form-control">
             Two
-            <input required className="is-invalid" type="checkbox" required />
+            <input required class="is-invalid" type="checkbox" required />
             <span></span>
             <i></i>
           </label>
         </div>
       </fieldset>
-      <span className="form-info">Error</span>
+      <span class="form-info">Error</span>
     </div>
   </form>
 </Canvas>

--- a/libs/chlorophyll/scss/components/form/stepper/stepper.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/stepper/stepper.stories.mdx
@@ -1,6 +1,6 @@
-import {Meta, Story, Canvas} from '@storybook/addon-docs'
+import { Meta, Story, Canvas } from '@storybook/addon-docs'
 
-export const Template = ({validation, enabled, text, formInfo}) => {
+export const Template = ({ validation, enabled, text, formInfo }) => {
   const attrValidation = validation ? validation : ``
   const attrEnabled = enabled ? `` : `disabled`
   const hasExtraInfo = formInfo.length > 0
@@ -20,7 +20,7 @@ export const Template = ({validation, enabled, text, formInfo}) => {
 <Meta
   title="Components/Form/Elements/Stepper"
   parameters={{
-    componentIds: ['component-stepper']
+    componentIds: ['component-stepper'],
   }}
   argTypes={{
     validation: {
@@ -28,10 +28,10 @@ export const Template = ({validation, enabled, text, formInfo}) => {
       options: ['', 'is-valid', 'is-invalid'],
     },
     enabled: {
-      control: 'boolean'
+      control: 'boolean',
     },
-    text: {control: 'text'},
-    formInfo: {control: 'text'}
+    text: { control: 'text' },
+    formInfo: { control: 'text' },
   }}
 />
 
@@ -39,10 +39,11 @@ export const Template = ({validation, enabled, text, formInfo}) => {
   name="Stepper"
   args={{
     text: 'Stepper label',
-    formInfo: 'Lorem ipsum very long description of stepper and what should be entered',
-    enabled: true
+    formInfo:
+      'Lorem ipsum very long description of stepper and what should be entered',
+    enabled: true,
   }}
-  parameters={{docs: {disable: true}}}
+  parameters={{ docs: { disable: true } }}
 >
   {Template.bind({})}
 </Story>
@@ -53,11 +54,13 @@ export const Template = ({validation, enabled, text, formInfo}) => {
   <form>
     <div class="form-group">
       <label for="stepperInput">Stepper label</label>
-      <span class="form-info">Lorem ipsum very long description of stepper and what should be entered</span>
+      <span class="form-info">
+        Lorem ipsum very long description of stepper and what should be entered
+      </span>
       <div class="group group-border group-stepper">
-        <button className="tertiary">-</button>
-        <input id="stepperInput" type="number" placeholder="0"/>
-        <button className="tertiary">+</button>
+        <button class="tertiary">-</button>
+        <input id="stepperInput" type="number" placeholder="0" />
+        <button class="tertiary">+</button>
       </div>
       <span class="form-info">Neutral</span>
     </div>
@@ -68,29 +71,28 @@ export const Template = ({validation, enabled, text, formInfo}) => {
   <form>
     <div class="form-group">
       <label for="stepperInput">Stepper label</label>
-      <div className="horizontal">
+      <div class="horizontal">
         <div>
-        <div>
-          <span class="form-info">Vuxna</span>
-          <div class="group group-border group-stepper">
-            <button className="tertiary">-</button>
-            <input id="stepperInput" type="number" placeholder="0"/>
-            <button className="tertiary">+</button>
+          <div>
+            <span class="form-info">Vuxna</span>
+            <div class="group group-border group-stepper">
+              <button class="tertiary">-</button>
+              <input id="stepperInput" type="number" placeholder="0" />
+              <button class="tertiary">+</button>
+            </div>
           </div>
         </div>
-        </div>
         <div>
-        <div>
-          <span class="form-info">Barn under 18</span>
-          <div class="group group-border group-stepper">
-            <button className="tertiary">-</button>
-            <input id="stepperInput" type="number" placeholder="0"/>
-            <button className="tertiary">+</button>
+          <div>
+            <span class="form-info">Barn under 18</span>
+            <div class="group group-border group-stepper">
+              <button class="tertiary">-</button>
+              <input id="stepperInput" type="number" placeholder="0" />
+              <button class="tertiary">+</button>
+            </div>
           </div>
-        </div>
         </div>
       </div>
     </div>
   </form>
 </Canvas>
-

--- a/libs/chlorophyll/scss/components/list/list.stories.mdx
+++ b/libs/chlorophyll/scss/components/list/list.stories.mdx
@@ -1,4 +1,4 @@
-import {Meta, Canvas, Story} from '@storybook/addon-docs/blocks'
+import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks'
 
 export const Template = ({ text, className }) => `
   <ol>
@@ -11,63 +11,67 @@ export const Template = ({ text, className }) => `
 <Meta
   title="Components/List"
   parameters={{
-    componentIds: ['component-list']
+    componentIds: ['component-list'],
   }}
 />
 
 ### Unordered list
+
 <Canvas>
-    <ul>
-      <li>First</li>
-      <li>Second</li>
-      <li>Third</li>
-    </ul>
+  <ul>
+    <li>First</li>
+    <li>Second</li>
+    <li>Third</li>
+  </ul>
 </Canvas>
 
 ### Check list
 
 <Canvas>
-    <ul class="check">
-      <li>First</li>
-      <li>Second</li>
-      <li>Third</li>
-    </ul>
+  <ul class="check">
+    <li>First</li>
+    <li>Second</li>
+    <li>Third</li>
+  </ul>
 </Canvas>
 
 ### Value list
+
 <Canvas>
-    <dl className="gds-list">
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-    </dl>
+  <dl class="gds-list">
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+  </dl>
 </Canvas>
 
 #### Inverted
+
 <Canvas>
-    <dl className="gds-list gds-list--inverted">
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-    </dl>
+  <dl class="gds-list gds-list--inverted">
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+  </dl>
 </Canvas>
 
 #### Horizontal
+
 <Canvas>
-    <dl className="gds-list gds-list--horizontal">
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-      <dt>Label</dt>
-      <dd>Value</dd>
-    </dl>
+  <dl class="gds-list gds-list--horizontal">
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+    <dt>Label</dt>
+    <dd>Value</dd>
+  </dl>
 </Canvas>
 
 ### List Group

--- a/libs/chlorophyll/scss/components/skeleton-loader/skeleton-loader.stories.mdx
+++ b/libs/chlorophyll/scss/components/skeleton-loader/skeleton-loader.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Canvas } from '@storybook/addon-docs'
 <Meta
   title="Components/Skeleton loader"
   parameters={{
-    componentIds: ['component-skeleton-loader']
+    componentIds: ['component-skeleton-loader'],
   }}
 />
 
@@ -12,94 +12,162 @@ import { Meta, Canvas } from '@storybook/addon-docs'
 Skeleton loaders are used to show a loading state while data is being fetched.
 
 ### Default skeleton loader
+
 A skeleton loader for generic content.
 
 <Canvas>
-  <div className="skeleton-loader" aria-busy="true">Loading content</div>
+  <div class="skeleton-loader" aria-busy="true">
+    Loading content
+  </div>
 </Canvas>
-
 
 ### Default background color
 
 Since examples here are rendered in canvas elements that resemble using skeleton loaders in cards, here's and example of a skeleton loader against the default background color.
+
 <Canvas>
   <div class="bg-color p-5 m-n5">
-    <div class="skeleton-loader" aria-busy="true">Loading content</div>
+    <div class="skeleton-loader" aria-busy="true">
+      Loading content
+    </div>
   </div>
 </Canvas>
 
 ### Table
+
 A skeleton loader for tables.
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-table" aria-busy="true">Loading table</div>
+  <div class="skeleton-loader skeleton-loader-table" aria-busy="true">
+    Loading table
+  </div>
 </Canvas>
 
 ### Fill
+
 Use `skeleton-loader-fill` to create custom skeleton templates for things like forms, buttons etc. Add utility classes like `rounded` or `rounded-circle` to adjust the shape and specify size using custom class or with inline styles.
 
 <Canvas>
   <div class="d-flex align-items-center">
     <div class="form-group">
       <label for="inputInvalid">Input label</label>
-      <span class="form-info">Lorem ipsum very long description of input and what should be entered</span>
+      <span class="form-info">
+        Lorem ipsum very long description of input and what should be entered
+      </span>
       <input id="inputInvalid" type="text" />
       <span class="form-info">Neutral</span>
     </div>
     <div class="ms-5">
-      <div class="skeleton-loader skeleton-loader-fill mb-3 rounded" aria-busy="true" style={{height: '1.125rem',width:'100px'}}></div>
-      <div class="skeleton-loader skeleton-loader-fill mb-3 rounded" aria-busy="true" style={{height: '1.75rem',width:'160px'}}></div>
-      <div class="skeleton-loader skeleton-loader-fill mb-3 rounded" aria-busy="true" style={{height: '2.75rem',width:'200px'}}>Loading form</div>
-      <div class="skeleton-loader skeleton-loader-fill mb-4 rounded" aria-busy="true" style={{height: '1rem',width:'80px'}}></div>
+      <div
+        class="skeleton-loader skeleton-loader-fill mb-3 rounded"
+        aria-busy="true"
+        style={{ height: '1.125rem', width: '100px' }}
+      ></div>
+      <div
+        class="skeleton-loader skeleton-loader-fill mb-3 rounded"
+        aria-busy="true"
+        style={{ height: '1.75rem', width: '160px' }}
+      ></div>
+      <div
+        class="skeleton-loader skeleton-loader-fill mb-3 rounded"
+        aria-busy="true"
+        style={{ height: '2.75rem', width: '200px' }}
+      >
+        Loading form
+      </div>
+      <div
+        class="skeleton-loader skeleton-loader-fill mb-4 rounded"
+        aria-busy="true"
+        style={{ height: '1rem', width: '80px' }}
+      ></div>
     </div>
     <div class="ms-5">
-      <div class="skeleton-loader skeleton-loader-fill mb-3 rounded-circle" aria-busy="true" style={{height: '100px',width:'100px'}}>Loading circle</div>
+      <div
+        class="skeleton-loader skeleton-loader-fill mb-3 rounded-circle"
+        aria-busy="true"
+        style={{ height: '100px', width: '100px' }}
+      >
+        Loading circle
+      </div>
     </div>
   </div>
 </Canvas>
 
 ## Charts
+
 Skeleton loaders for donut, bar and area charts placed inside a flexbox grid.
 
 <Canvas>
   <div class="row gy-3">
     <div class="col-12 col-sm">
-      <div class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-donut skeleton-loader-no-stretch" aria-busy="true">Loading chart</div>
+      <div
+        class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-donut skeleton-loader-no-stretch"
+        aria-busy="true"
+      >
+        Loading chart
+      </div>
     </div>
     <div class="col-12 col-sm">
-      <div class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-bar skeleton-loader-no-stretch" aria-busy="true">Loading chart</div>
+      <div
+        class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-bar skeleton-loader-no-stretch"
+        aria-busy="true"
+      >
+        Loading chart
+      </div>
     </div>
     <div class="col-12 col-sm">
-      <div class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-area skeleton-loader-no-stretch" aria-busy="true">Loading chart</div>
+      <div
+        class="mx-sm-5 my-5 skeleton-loader skeleton-loader-chart-area skeleton-loader-no-stretch"
+        aria-busy="true"
+      >
+        Loading chart
+      </div>
     </div>
   </div>
 </Canvas>
 
 ### Stretch
+
 Use the `skeleton-loader-no-stretch` modifier to disable mask stretch.
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-chart-bar" aria-busy="true">Loading chart</div>
+  <div class="skeleton-loader skeleton-loader-chart-bar" aria-busy="true">
+    Loading chart
+  </div>
 </Canvas>
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-chart-bar skeleton-loader-no-stretch" aria-busy="true">Loading chart</div>
+  <div
+    class="skeleton-loader skeleton-loader-chart-bar skeleton-loader-no-stretch"
+    aria-busy="true"
+  >
+    Loading chart
+  </div>
 </Canvas>
 
 ### Horizontal bar chart
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-chart-bar-horizontal" aria-busy="true">Loading chart</div>
+  <div
+    class="skeleton-loader skeleton-loader-chart-bar-horizontal"
+    aria-busy="true"
+  >
+    Loading chart
+  </div>
 </Canvas>
 
 ### Horizontal area chart
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-chart-area" aria-busy="true">Loading chart</div>
+  <div class="skeleton-loader skeleton-loader-chart-area" aria-busy="true">
+    Loading chart
+  </div>
 </Canvas>
 
 ### Horizontal bubble chart
 
 <Canvas>
-  <div class="skeleton-loader skeleton-loader-chart-bubble" aria-busy="true">Loading chart</div>
+  <div class="skeleton-loader skeleton-loader-chart-bubble" aria-busy="true">
+    Loading chart
+  </div>
 </Canvas>

--- a/libs/chlorophyll/scss/components/typography/typography.stories.mdx
+++ b/libs/chlorophyll/scss/components/typography/typography.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Canvas } from '@storybook/addon-docs'
 
 <Canvas>
   <div>
-    <div className="display-01">Display 01</div>
+    <div class="display-01">Display 01</div>
     <h1>H1</h1>
     <h2>H2</h2>
     <h3>H3</h3>

--- a/libs/react/src/lib/badge/badge.stories.mdx
+++ b/libs/react/src/lib/badge/badge.stories.mdx
@@ -12,7 +12,7 @@ Simple Badge Component
 <Story
   name="Badge"
   parameters={{
-    componentIds: ['component-badge']
+    componentIds: ['component-badge'],
   }}
   args={{
     children: 'Primary',


### PR DESCRIPTION
Some people were having issues which were caused by copy-pasted examples from Chlorophyll where React-style `className` was used instead of `class`.