### PR TITLE
Text inputs should not have the pointer (hand) cursor

### DIFF
--- a/libs/chlorophyll/scss/components/form/input/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/input/_mixins.scss
@@ -28,7 +28,6 @@ $background: var(--sg-form-control-bg);
     @include common.add-focus();
     background-color: $background;
     color: $_color;
-    cursor: pointer;
     min-height: 2.75rem;
     display: flex;
     align-items: center;


### PR DESCRIPTION
Text input fields should have a regular text cursor on hover. Currently they have the `pointer` cursor type, which is typically associated with links or other interactive elements which can receive click actions.

Closes #323