### PR TITLE
fix: 🐛 match form info color to feedback

### DIFF
--- a/libs/chlorophyll/scss/components/form/group/group.stories.mdx
+++ b/libs/chlorophyll/scss/components/form/group/group.stories.mdx
@@ -10,7 +10,7 @@ Group inputs, buttons and other form elements together using <code>.group</code>
 
 <Canvas>
   <div class="group">
-    <input type="text" placeholder="Input field"/>
+    <input type="text" placeholder="Input field" />
     <button type="button">Button</button>
   </div>
 </Canvas>
@@ -21,34 +21,45 @@ Group inputs, buttons and other form elements together using <code>.group</code>
   <div class="group">
     <button type="button">Button</button>
     <button type="button">Button</button>
-    <button type="button" class="active">Button</button>
+    <button type="button" class="active">
+      Button
+    </button>
   </div>
 </Canvas>
 
 <Canvas>
   <div class="group size-sm">
-    <button type="button" class="ghost">Button</button>
-    <button type="button" class="ghost">Button</button>
-    <button type="button" class="ghost active">Button</button>
-    <button type="button" class="ghost">Button</button>
+    <button type="button" class="ghost">
+      Button
+    </button>
+    <button type="button" class="ghost">
+      Button
+    </button>
+    <button type="button" class="ghost active">
+      Button
+    </button>
+    <button type="button" class="ghost">
+      Button
+    </button>
   </div>
 </Canvas>
 
 ## Inputs
+
 <Canvas>
   <form>
     <div class="form-group">
       <div class="group">
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
       </div>
-  </div>
+    </div>
     <div class="form-group">
       <div class="group is-invalid">
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
       </div>
       <span class="form-info">Error</span>
     </div>
@@ -61,16 +72,16 @@ Group inputs, buttons and other form elements together using <code>.group</code>
   <form>
     <div class="form-group">
       <div class="group group-border">
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
       </div>
     </div>
     <div class="form-group">
       <div class="group group-border is-invalid">
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
-        <input type="text" placeholder="Input field"/>
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
+        <input type="text" placeholder="Input field" />
       </div>
       <span class="form-info">Error</span>
     </div>
@@ -80,19 +91,39 @@ Group inputs, buttons and other form elements together using <code>.group</code>
 ### Static text
 
 <Canvas>
-  <div class="group group-border">
-    <input type="text" placeholder="Some text"/>
-    <span class="form-text">Static</span>
-  </div>
+  <form>
+    <div class="form-group">
+      <div class="group group-border">
+        <input type="text" placeholder="Some text" />
+        <span class="form-text">Static</span>
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="group group-border is-valid">
+        <input type="text" placeholder="Some text" />
+        <span class="form-text">Static</span>
+      </div>
+      <span class="form-info">Success</span>
+    </div>
+    <div class="form-group">
+      <div class="group group-border is-invalid">
+        <input type="text" placeholder="Some text" />
+        <span class="form-text">Static</span>
+      </div>
+      <span class="form-info">Error</span>
+    </div>
+  </form>
 </Canvas>
 
 ### Input and buttons
 
 <Canvas>
   <div class="group group-border">
-    <input type="text" placeholder="Some text"/>
+    <input type="text" placeholder="Some text" />
     <button type="button">Button</button>
-    <button type="button" class="primary">Button</button>
+    <button type="button" class="primary">
+      Button
+    </button>
   </div>
 </Canvas>
 
@@ -100,21 +131,25 @@ Group inputs, buttons and other form elements together using <code>.group</code>
 
 <Canvas>
   <div class="group size-sm">
-    <input type="text" placeholder="Some text"/>
+    <input type="text" placeholder="Some text" />
     <button class="primary">Button</button>
   </div>
 </Canvas>
 
 <Canvas>
   <div class="group">
-    <input type="text" placeholder="Some text"/>
-    <button type="button" class="primary">Button</button>
+    <input type="text" placeholder="Some text" />
+    <button type="button" class="primary">
+      Button
+    </button>
   </div>
 </Canvas>
 
 <Canvas>
   <div class="group size-lg">
-    <input type="text" placeholder="Some text"/>
-    <button type="button" class="primary">Button</button>
+    <input type="text" placeholder="Some text" />
+    <button type="button" class="primary">
+      Button
+    </button>
   </div>
 </Canvas>

--- a/libs/chlorophyll/scss/components/form/validation/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/validation/_mixins.scss
@@ -16,7 +16,7 @@ $_border-width: var(--sg-border-width);
     height: 4px;
     position: absolute;
 
-    @if($transform) {
+    @if ($transform) {
       transform: translate3d(0, -12px, 0);
     }
 
@@ -55,8 +55,13 @@ $_border-width: var(--sg-border-width);
   .was-validated textarea:not(.is-invalid):valid + .form-info,
   .was-validated fieldset:not(.is-invalid).is-valid:valid + .form-info,
   .is-valid:not(.group) ~ .form-info,
-  .is-valid:is(.group){
+  .is-valid .gds-form-item__footer .form-info,
+  .is-valid:is(.group) {
     @include add-feedback(tokens.$intent-success-background);
+
+    &.is-valid:is(.group) + .form-info {
+      color: tokens.$intent-success-background;
+    }
   }
 
   .was-validated input:not(.is-valid):invalid + .form-info,
@@ -66,6 +71,10 @@ $_border-width: var(--sg-border-width);
   .is-invalid .gds-form-item__footer .form-info,
   .is-invalid:is(.group) {
     @include add-feedback(tokens.$intent-danger-background);
+
+    &.is-invalid:is(.group) + .form-info {
+      color: tokens.$intent-danger-background;
+    }
   }
 }
 


### PR DESCRIPTION
[Form info of grouped elements have incorrect text color](https://github.com/sebgroup/green/issues/805):
![image](https://user-images.githubusercontent.com/82629695/226800077-b6085407-cdea-451d-9dfd-7e79b8011354.png)

Fix:
![image](https://user-images.githubusercontent.com/82629695/226800190-9d1683a0-8a25-4f5f-9cd8-f8d09868246a.png)
