### PR TITLE
fix: 🐛 make static text fixed at the end of parent element

### DIFF
--- a/libs/chlorophyll/scss/components/form/group/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/group/_mixins.scss
@@ -28,6 +28,10 @@ $_background: input.$background;
     }
   }
 
+  > span.form-text {
+    justify-content: flex-end;
+  }
+
   @include common.media-breakpoint-up('sm') {
     > input {
       flex: 1 1 auto;


### PR DESCRIPTION
Issue [#816](https://github.com/sebgroup/green/issues/816):
![image](https://user-images.githubusercontent.com/82629695/228758074-64daaafb-d43a-4dcc-b192-7de949c71806.png)

Fix:
![image](https://user-images.githubusercontent.com/82629695/228758175-0254a36d-5067-4f3c-9a24-8fe435030310.png)
