### PR TITLE
fix: use fully qualified import for `swiped-events`

### DIFF
--- a/libs/extract/src/lib/common/helper-functions.ts
+++ b/libs/extract/src/lib/common/helper-functions.ts
@@ -1,6 +1,6 @@
 export const addSwipeEvents = () => {
   // https://github.com/john-doherty/swiped-events
-  import('swiped-events/dist/swiped-events.min' as never)
+  import('swiped-events/dist/swiped-events.min.js' as never)
 }
 
 export const scrollElementIntoView = (element: HTMLElement) => {


### PR DESCRIPTION
Some people where reporting issues compiling extract with Webpack due to a sub-dependency called `swiped-events` failing to import properly. This change should hopefully fix that issue.

@astrit FYI!