### PR TITLE
docs(radio-group): improve `RadioGroup` documentation for React

### DIFF
--- a/libs/react/src/lib/form/radioButton/radioGroup.stories.mdx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.stories.mdx
@@ -1,19 +1,29 @@
-import {Meta, Story, Canvas, ArgsTable} from '@storybook/addon-docs'
-import {RadioButton} from '../input/input'
-import {RadioGroup} from './radioGroup'
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
+import { RadioButton } from '../input/input'
+import { RadioGroup } from './radioGroup'
 
-export const RadioButtonTemplate = ({...props}) => <RadioButton {...props} />
+export const RadioButtonTemplate = ({ ...props }) => <RadioButton {...props} />
 
-export const RadioGroupTemplate = ({...props}) => <RadioGroup {...props}>
-  <RadioButton value={'value-1'} label="First label"/>
-  <RadioButton value={'value-2'} label="Second label"/>
-</RadioGroup>
+export const RadioGroupTemplate = ({ ...props }) => (
+  <RadioGroup {...props}>
+    <RadioButton value={'value-1'} label="First label" />
+    <RadioButton value={'value-2'} label="Second label" />
+  </RadioGroup>
+)
 
-<Meta title="Components/RadioGroup" component={RadioGroup}/>
+<Meta title="Components/RadioGroup" component={RadioGroup} />
 
-# Radio Group
+## RadioGroup and RadioButton Components
 
-Simple Radio Button Component
+### RadioGroup
+
+`RadioGroup` is a container component for managing radio buttons, ensuring only one can be selected at a time. It provides customization options such as horizontal alignment, default selection, and expandable information. The component can also be configured with validation functions and event handlers.
+
+### RadioButton
+
+`RadioButton` represents an individual radio button within a `RadioGroup`. It extends native HTML input properties for customization. Each `RadioButton` can have its own label, value, and optional test ID. Validation functions can be applied to individual radio buttons if needed.
+
+Together, `RadioGroup` and `RadioButton` components facilitate the use of radio buttons in React applications.
 
 ### Default Radio Group
 
@@ -21,11 +31,11 @@ Simple Radio Button Component
   <Story
     name="Default"
     parameters={{
-      componentIds: ['component-radiogroup']
+      componentIds: ['component-radiogroup'],
     }}
     args={{
       label: 'Radio group',
-      labelInformation: 'This is longer information describing the input'
+      labelInformation: 'This is longer information describing the input',
     }}
   >
     {RadioGroupTemplate.bind({})}
@@ -36,13 +46,14 @@ Simple Radio Button Component
 
 <Canvas>
   <Story name="Expandable information">
-    <RadioGroup label="Radio Group"
-                labelInformation="Radio Group Description"
-                expandableInfo="This is a long expandable information that can be sent to the radio group component"
-                expandableInfoButtonLabel="Toggle additional information"
+    <RadioGroup
+      label="Radio Group"
+      labelInformation="Radio Group Description"
+      expandableInfo="This is a long expandable information that can be sent to the radio group component"
+      expandableInfoButtonLabel="Toggle additional information"
     >
-      <RadioButton label="Radio Button 1" name="name" value="button1"/>
-      <RadioButton label="Radio Button 2" name="name" value="button2"/>
+      <RadioButton label="Radio Button 1" name="name" value="button1" />
+      <RadioButton label="Radio Button 2" name="name" value="button2" />
     </RadioGroup>
   </Story>
 </Canvas>
@@ -51,12 +62,17 @@ Simple Radio Button Component
 
 <Canvas>
   <Story name="Validation">
-    <RadioGroup label="Radio Group"
-                labelInformation="Radio Group Description"
-                validator={{message: "This form item is invalid! And what happens if its really long?", indicator: "error"}}
+    <RadioGroup
+      label="Radio Group"
+      labelInformation="Radio Group Description"
+      validator={{
+        message:
+          'This form item is invalid! And what happens if its really long?',
+        indicator: 'error',
+      }}
     >
-      <RadioButton label="Radio Button 1" name="name" value="button1"/>
-      <RadioButton label="Radio Button 2" name="name" value="button2"/>
+      <RadioButton label="Radio Button 1" name="name" value="button1" />
+      <RadioButton label="Radio Button 2" name="name" value="button2" />
     </RadioGroup>
   </Story>
 </Canvas>
@@ -65,16 +81,49 @@ Simple Radio Button Component
 
 <Canvas>
   <Story name="Horizontal">
-    <RadioGroup label="Radio Group"
-                labelInformation="Radio Group Description"
-                validator={{message: "This form item is invalid! And what happens if its really long?", indicator: "error"}}
-                horizontal
+    <RadioGroup
+      label="Radio Group"
+      labelInformation="Radio Group Description"
+      validator={{
+        message:
+          'This form item is invalid! And what happens if its really long?',
+        indicator: 'error',
+      }}
+      horizontal
     >
-      <RadioButton label="Radio Button 1" name="name" value="button1"/>
-      <RadioButton label="Radio Button 2" name="name" value="button2"/>
+      <RadioButton label="Radio Button 1" name="name" value="button1" />
+      <RadioButton label="Radio Button 2" name="name" value="button2" />
     </RadioGroup>
   </Story>
 </Canvas>
 
+### Props of RadioGroup
 
-<ArgsTable of={RadioButton}/>
+| Prop                       | Type                                               | Description                                                                                                   |
+| :------------------------- | :------------------------------------------------- | :------------------------------------------------------------------------------------------------------------ |
+| label?                     | `string`                                           | Label for the radio group                                                                                     |
+| title?                     | `string`                                           | Title for the radio group                                                                                     |
+| labelInformation?          | `string`                                           | Additional information for the label                                                                          |
+| valueSelected?             | `string`                                           | The currently selected value in the radio group. Needs to match the string value of an enclosed `RadioButton` |
+| description?               | `string`                                           | Description for the radio group                                                                               |
+| expandableInfo?            | `string`                                           | Expandable information text                                                                                   |
+| expandableInfoButtonLabel? | `string`                                           | Label for the expandable info button                                                                          |
+| defaultSelected?           | `string`                                           | Default selected value in the radio group                                                                     |
+| validator?                 | `IValidator`                                       | Validator function for radio group values                                                                     |
+| onChangeRadio?             | `(value: string) => string`                        | Function called when radio button selection changes                                                           |
+| onChange?                  | `(e: React.ChangeEvent<HTMLInputElement>) => void` | Function called with the raw DOM event when a selection changes                                               |
+| name?                      | `string`                                           | Name attribute for the radio group                                                                            |
+| horizontal?                | `boolean`                                          | Whether or not the radio buttons are displayed horizontally                                                   |
+
+### Props of RadioButton
+
+Please note that since the `RadioButtonProps` interface extends `HTMLProps<HTMLInputElement>`, this table only covers the additional properties specific to `RadioButtonProps`. The interface also includes all properties from `HTMLProps<HTMLInputElement>`.
+
+| Prop       | Type     | Description                                         |
+| :--------- | :------- | :-------------------------------------------------- |
+| label      | `string` | Label for the radio button                          |
+| testId?    | `string` | Test ID for the radio button (for testing purposes) |
+| validator? | `string` | Validator function for radio button value           |
+| value      | `string` | Value of the radio button                           |
+
+<ArgsTable of={RadioGroupTemplate} />


### PR DESCRIPTION
This PR adds improved documentation for the `RadioGroup` and `RadioButton` components in React