### PR TITLE
style: 💄 Add font-weight 500 to table th

### DIFF
--- a/libs/chlorophyll/scss/components/table/_mixins.scss
+++ b/libs/chlorophyll/scss/components/table/_mixins.scss
@@ -23,7 +23,7 @@ $_breakpoint-mobile-layout: map.get(tokens.$grid-breakpoints, 'sm');
         padding: $_cell-padding-y $_cell-padding-x;
         vertical-align: top;
         text-align: left;
-        // sort button
+        font-weight: 500;
         .sg-table-sort {
           color: inherit;
           width: 100%;


### PR DESCRIPTION
As it was reported there was thing minor inconsistency between Figma and code where table <th> was not using `font-weight: 500`

✅ Closes: #842