### PR TITLE
fix(Input): remove redundant state hooks

### DIFF
--- a/libs/react/src/lib/form/useInput.ts
+++ b/libs/react/src/lib/form/useInput.ts
@@ -1,12 +1,5 @@
 import { randomId } from '@sebgroup/extract'
-import React, {
-  InputHTMLAttributes,
-  RefObject,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, { InputHTMLAttributes, RefObject, useMemo, useRef } from 'react'
 
 const useInput = (
   props: InputHTMLAttributes<HTMLInputElement>,
@@ -17,33 +10,8 @@ const useInput = (
 } => {
   const id = useMemo(() => props.id || randomId(), [props.id])
   const ref = useRef<HTMLInputElement>(null)
-  const [value, setValue] = useState(props.value ? props.value : '')
-  const [checked, setChecked] = useState(props.checked ? props.checked : false)
-
-  useEffect(() => {
-    if (props.value !== undefined) setValue(props.value)
-
-    if (ref.current && ref.current.form) {
-      const resetListener = (): void => {
-        setValue(props.value ? props.value : '')
-        setChecked(props.checked ? props.checked : false)
-      }
-      const form = ref.current.form
-      form.addEventListener('reset', resetListener)
-      return () => form.removeEventListener('reset', resetListener)
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      return () => {}
-    }
-  }, [props])
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (props.value === undefined) {
-      setValue(event.target.value)
-    }
-
-    setChecked(event.currentTarget.checked)
-
     onChanges && onChanges(event)
     onChangeInput && onChangeInput(event.target.value)
   }
@@ -52,8 +20,6 @@ const useInput = (
     ...props,
     id,
     ref,
-    value,
-    checked,
     onChange,
   }
 }


### PR DESCRIPTION
This PR removes redundant state hooks in the React input component. These hooks cause unnecessary re-rendering of the component, which can make it awkward to use, and the `value` and `checked` states are already held in the native input element, so there's no need to duplicate them in state hooks.