### PR TITLE
feat(slider): add value prop

### DIFF
--- a/libs/react/src/lib/slider/slider.spec.tsx
+++ b/libs/react/src/lib/slider/slider.spec.tsx
@@ -1,0 +1,57 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { Slider } from './slider'
+
+describe('Slider', () => {
+  it('should render', () => {
+    const { container } = render(<Slider />)
+    expect(container.querySelector('input')?.getAttribute('type')).toBe('range')
+  })
+
+  it('should render with value', () => {
+    const { container } = render(<Slider value={10} />)
+    expect(container.querySelector('input')?.getAttribute('value')).toBe('10')
+  })
+
+  it('should render with min', () => {
+    const { container } = render(<Slider min={10} />)
+    expect(container.querySelector('input')?.getAttribute('min')).toBe('10')
+  })
+
+  it('should render with max', () => {
+    const { container } = render(<Slider max={10} />)
+    expect(container.querySelector('input')?.getAttribute('max')).toBe('10')
+  })
+
+  it('should render with step', () => {
+    const { container } = render(<Slider step={10} />)
+    expect(container.querySelector('input')?.getAttribute('step')).toBe('10')
+  })
+
+  it('should render with disabled', () => {
+    const { container } = render(<Slider disabled />)
+    expect(container.querySelector('input')?.getAttribute('disabled')).toBe('')
+  })
+
+  it('should render with label', () => {
+    render(<Slider label="Test label" />)
+    expect(screen.getByText('Test label')).not.toBeNull()
+  })
+
+  it('should update value', () => {
+    const { container, rerender } = render(<Slider />)
+    const input = container.querySelector('input') as HTMLInputElement
+    act(() => {
+      rerender(<Slider value={10} />)
+    })
+    expect(input.value).toBe('10')
+  })
+
+  it('should fire onChange', () => {
+    const onChange = jest.fn()
+    const { container } = render(<Slider onChange={onChange} />)
+    const input = container.querySelector('input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 10 } })
+    expect(onChange).toBeCalled()
+  })
+})

--- a/libs/react/src/lib/slider/slider.stories.mdx
+++ b/libs/react/src/lib/slider/slider.stories.mdx
@@ -22,7 +22,7 @@ On pages where the user can experiment or adjust values in a scale, such as "How
 | Prop          | Type      | Description                                                                           |
 | :------------ | :-------- | :------------------------------------------------------------------------------------ |
 | name?         | `string`  | Name of the input element                                                             |
-| defaultValue? | `number`  | Default value of the input element                                                    |
+| value?        | `number`  | Value of the input element                                                            |
 | min           | `number`  | The greatest value in the range of permitted values. Default is 0                     |
 | max           | `number`  | The lowest value in the range of permitted values. Default is 100                     |
 | step          | `number`  | The number that specifies the granularity that the value must adhere to. Default is 1 |
@@ -43,8 +43,8 @@ On pages where the user can experiment or adjust values in a scale, such as "How
         type: 'text',
       },
     },
-    defaultValue: {
-      name: 'defaultValue',
+    value: {
+      name: 'value',
       defaultValue: 50,
       control: {
         type: 'number',

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -28,6 +28,7 @@ const InputWrapper = ({
 
 export function Slider({
   name = `${randomId()}-slider`,
+  value,
   defaultValue,
   min = 0,
   max = 100,
@@ -42,7 +43,7 @@ export function Slider({
 }: SliderProps) {
   const [background, setBackground] = React.useState<string>()
   const [sliderValue, setSliderValue] = React.useState<number>(
-    defaultValue ?? 0
+    value ?? defaultValue ?? 0
   )
 
   React.useLayoutEffect(() => {
@@ -54,6 +55,10 @@ export function Slider({
     const percent: number = ((sliderValue - min) / (max - min)) * 100
     setBackground(getSliderTrackBackground(percent))
   }, [disabled, sliderValue])
+
+  React.useEffect(() => {
+    setSliderValue(Number(value))
+  }, [value])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target

--- a/libs/react/src/types/props/index.ts
+++ b/libs/react/src/types/props/index.ts
@@ -18,7 +18,7 @@ export interface LabelProps {
 
 export interface SliderProps {
   name?: string
-  defaultValue?: number
+  value?: number
   min?: number
   max?: number
   step?: number
@@ -29,4 +29,9 @@ export interface SliderProps {
   unitLabel?: string
   disabled?: boolean
   onChange?: (value: number) => void
+
+  /**
+   * @deprecated Use `value` instead
+   */
+  defaultValue?: number
 }


### PR DESCRIPTION
Allows setting the value for Slider. Deprecates the `defaultValue` prop.