### PR TITLE
fix: 🐛 Missing Output decorator to wizard step card

### DIFF
--- a/libs/angular/src/lib/in-page-wizard/in-page-wizard-step-card.component.ts
+++ b/libs/angular/src/lib/in-page-wizard/in-page-wizard-step-card.component.ts
@@ -9,8 +9,10 @@ export class NggInPageWizardStepCardComponent {
   readonly handleNextClick: EventEmitter<MouseEvent> =
     new EventEmitter<MouseEvent>()
 
+  @Output()
   readonly handleEditClick: EventEmitter<MouseEvent> =
     new EventEmitter<MouseEvent>()
+
   @Input() public stepText = ''
 
   @Input() public title = ''


### PR DESCRIPTION
Add Missing Output decorator to in-page wizard step card