### PR TITLE
feat(dropdown): allow custom template for dropdown button

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown-button.directive.ts
+++ b/libs/angular/src/lib/dropdown/dropdown-button.directive.ts
@@ -1,0 +1,8 @@
+import { Directive, TemplateRef } from '@angular/core'
+
+@Directive({
+  selector: '[nggDropdownButton]',
+})
+export class NggDropdownButtonDirective {
+  constructor(public templateRef: TemplateRef<unknown>) {}
+}

--- a/libs/angular/src/lib/dropdown/dropdown.component.html
+++ b/libs/angular/src/lib/dropdown/dropdown.component.html
@@ -10,6 +10,7 @@
         : null
     "
     type="button"
+    role="combobox"
     #togglerRef
     [id]="toggler?.attributes?.id"
     [attr.aria-haspopup]="toggler?.attributes?.['aria-haspopup']"
@@ -48,14 +49,17 @@
     [style]="listbox?.attributes?.style"
     [class]="listbox?.classes"
   >
-    <button
-      type="button"
-      class="close m-4 m-sm-2 d-block d-sm-none"
-      (click)="handler?.close()"
-    >
-      <span class="sr-only">{{ dropdown?.texts?.close }}</span>
-      <i></i>
-    </button>
+    <div class="d-flex d-sm-none align-items-center">
+      <span class="flex-grow-1 ps-4 fs-2 fw-bolder">{{ label }}</span>
+      <button
+        type="button"
+        class="close m-4 m-sm-2 d-block d-sm-none"
+        [attr.aria-label]="dropdown?.texts?.close"
+        (click)="handler?.close()"
+      >
+        <i></i>
+      </button>
+    </div>
     <ul role="listbox" *ngIf="!dropdown?.isMultiSelect">
       <ng-container *ngTemplateOutlet="searchInput"></ng-container>
       <li

--- a/libs/angular/src/lib/dropdown/dropdown.component.html
+++ b/libs/angular/src/lib/dropdown/dropdown.component.html
@@ -22,7 +22,14 @@
     [class.is-valid]="valid"
     [class.is-invalid]="invalid"
   >
-    <span>{{ dropdown?.texts?.select }}</span>
+    <ng-container
+      *ngTemplateOutlet="
+        customButton?.templateRef && !multiSelect && selectedOption
+          ? customButton!.templateRef
+          : defaultButton;
+        context: { option: selectedOption }
+      "
+    ></ng-container>
   </button>
   <span
     class="form-info"
@@ -117,6 +124,10 @@
     </div>
   </div>
 </div>
+
+<ng-template #defaultButton let-selected="selected">
+  <span>{{ dropdown?.texts?.select }}</span>
+</ng-template>
 
 <ng-template #defaultOption let-option="option">
   {{ option[dropdown!.display] }}

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -34,6 +34,7 @@ import {
   SearchFilter,
 } from '@sebgroup/extract'
 import { NggDropdownOptionDirective } from './dropdown-option.directive'
+import { NggDropdownButtonDirective } from './dropdown-button.directive'
 
 @Component({
   selector: 'ngg-dropdown',
@@ -80,12 +81,20 @@ export class NggDropdownComponent
 
   @Input() set value(newValue: any) {
     this.handler?.selectByValue(newValue)
+    this._selectedOption = this.handler?.dropdown.options.find(
+      (o) => o.selected
+    )
     this._value = newValue
   }
   get value(): any {
     return this._value
   }
   private _value: any
+
+  get selectedOption() {
+    return this._selectedOption
+  }
+  private _selectedOption: DropdownOptionElement | undefined
 
   @Output() readonly valueChange: EventEmitter<any> = new EventEmitter<any>()
   @Output() readonly touched: EventEmitter<boolean> =
@@ -97,6 +106,9 @@ export class NggDropdownComponent
 
   @ContentChild(NggDropdownOptionDirective)
   customOption?: NggDropdownOptionDirective
+
+  @ContentChild(NggDropdownButtonDirective)
+  customButton?: NggDropdownButtonDirective
 
   onChangeFn?: (value: unknown) => void
   onTouchedFn?: () => void
@@ -146,7 +158,6 @@ export class NggDropdownComponent
       this.handler &&
       (changes.id || changes.texts || changes.loop || changes.options)
     ) {
-      
       this.handler.update(this.props)
     }
   }

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -81,9 +81,6 @@ export class NggDropdownComponent
 
   @Input() set value(newValue: any) {
     this.handler?.selectByValue(newValue)
-    this._selectedOption = this.handler?.dropdown.options.find(
-      (o) => o.selected
-    )
     this._value = newValue
   }
   get value(): any {
@@ -92,9 +89,8 @@ export class NggDropdownComponent
   private _value: any
 
   get selectedOption() {
-    return this._selectedOption
+    return this.handler?.dropdown.options.find((o) => o.selected)
   }
-  private _selectedOption: DropdownOptionElement | undefined
 
   @Output() readonly valueChange: EventEmitter<any> = new EventEmitter<any>()
   @Output() readonly touched: EventEmitter<boolean> =

--- a/libs/angular/src/lib/dropdown/dropdown.module.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.module.ts
@@ -2,10 +2,19 @@ import { NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { NggDropdownComponent } from './dropdown.component'
 import { NggDropdownOptionDirective } from './dropdown-option.directive'
+import { NggDropdownButtonDirective } from './dropdown-button.directive'
 
 @NgModule({
-  declarations: [NggDropdownComponent, NggDropdownOptionDirective],
+  declarations: [
+    NggDropdownComponent,
+    NggDropdownOptionDirective,
+    NggDropdownButtonDirective,
+  ],
   imports: [CommonModule],
-  exports: [NggDropdownComponent, NggDropdownOptionDirective],
+  exports: [
+    NggDropdownComponent,
+    NggDropdownOptionDirective,
+    NggDropdownButtonDirective,
+  ],
 })
 export class NggDropdownModule {}

--- a/libs/angular/src/lib/dropdown/dropdown.spec.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.spec.ts
@@ -104,7 +104,9 @@ describe('Dropdown', () => {
       it('sets toggler text', async () => {
         fireEvent.click(options[1])
         await waitFor(() =>
-          expect(toggleButton.innerHTML.trim()).toEqual('<span>B</span>')
+          expect(
+            toggleButton.innerHTML.trim().replace(/<!--[\s\S]*?-->/g, '')
+          ).toEqual('<span>B</span>')
         )
       })
     })

--- a/libs/angular/src/lib/dropdown/dropdown.spec.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.spec.ts
@@ -27,7 +27,7 @@ describe('Dropdown', () => {
     })
 
     const [_buttons, _listboxes, _fieldset, _options] = [
-      await component.findAllByRole('button'),
+      await component.findAllByRole('combobox'),
       await component.findAllByRole('listbox'),
       await component.findAllByRole('listbox'),
       await component.findAllByRole('option'),
@@ -263,7 +263,7 @@ describe('Dropdown', () => {
         component.change({ loop: true })
 
         const [_buttons, _listboxes, _options] = [
-          await component.findAllByRole('button'),
+          await component.findAllByRole('combobox'),
           await component.findAllByRole('listbox'),
           await component.findAllByRole('option'),
         ]

--- a/libs/angular/src/lib/dropdown/dropdown.stories.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.stories.ts
@@ -99,18 +99,24 @@ const CustomOptionTemplate: Story<NggDropdownComponent> = (
   return {
     component: NggDropdownComponent,
     template: `
-    <ngg-dropdown 
-      [texts]="texts" 
-      [options]="options" 
-      [(value)]="value" 
-      [loop]="loop" 
-      [multiSelect]="multiSelect" 
-      [searchable]="searchable" 
-      [searchFilter]="searchFilter" 
-      [compareWith]="compareWith" 
-      [useValue]="useValue" 
-      [display]="display" 
+    <ngg-dropdown
+      [texts]="texts"
+      [options]="options"
+      [(value)]="value"
+      [loop]="loop"
+      [multiSelect]="multiSelect"
+      [searchable]="searchable"
+      [searchFilter]="searchFilter"
+      [compareWith]="compareWith"
+      [useValue]="useValue"
+      [display]="display"
       [id]="id">
+      <ng-template nggDropdownButton let-option="option">
+        <div>
+          <div>{{ option.name }}</div>
+          <div style="font-size: 0.8em">{{ option.val.kitchen }}</div>
+        </div>
+      </ng-template>
       <ng-template nggDropdownOption let-option="option" let-index="index">
         <div>
           <div>{{ index }}. {{ option.name }}</div>
@@ -126,10 +132,10 @@ const CustomOptionTemplate: Story<NggDropdownComponent> = (
 export const CustomOption = CustomOptionTemplate.bind({})
 CustomOption.args = {
   id: '',
-  texts: { placeholder: 'Select meal(s)' },
+  texts: { placeholder: 'Select meal' },
   value: '',
   loop: true,
-  multiSelect: true,
+  multiSelect: false,
   searchable: true,
   useValue: 'val',
   display: 'name',

--- a/libs/angular/src/lib/dropdown/index.ts
+++ b/libs/angular/src/lib/dropdown/index.ts
@@ -1,3 +1,4 @@
 export * from './dropdown.component'
 export * from './dropdown.module'
 export * from './dropdown-option.directive'
+export * from './dropdown-button.directive'

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -64,14 +64,17 @@ export const Dropdown = ({
         <span>{togglerProps.children}</span>
       </button>
       <div {...getListBoxProps(listboxProps)} ref={listboxRef}>
-        <button
-          type="button"
-          className="close m-4 m-sm-2 d-block d-sm-none"
-          onClick={dropdown?.close}
-        >
-          <span className="sr-only">{dropdown?.dropdown.texts.close}</span>
-          <i></i>
-        </button>
+        <div className="d-flex d-sm-none align-items-center">
+          <span className="flex-grow-1 ps-4 fs-2 fw-bolder">{label}</span>
+          <button
+            type="button"
+            className="close m-4 m-sm-2 d-block d-sm-none"
+            onClick={dropdown?.close}
+            aria-label={dropdown?.dropdown.texts.close}
+          >
+            <i></i>
+          </button>
+        </div>
         {dropdown?.dropdown.isMultiSelect ? (
           <div className="sg-fieldset-container">
             <fieldset {...multiSelectProps.fieldsetProps}>


### PR DESCRIPTION
This PR adds the option of using a custom layout in the dropdown button, similar to how you can currently use custom layouts for the options in the popover.

Closes #834