### PR TITLE
fix(slider): allow `undefined` values

### DIFF
--- a/apps/react-lib-dev/src/app/app.tsx
+++ b/apps/react-lib-dev/src/app/app.tsx
@@ -30,7 +30,8 @@ export function App() {
   const [validator, setValidator] = useState<undefined | IValidator>(undefined)
 
   const [adults, setAdults] = useState<{ id: number; value: number }>()
-  const [sliderValue, setSliderValue] = useState<number>(0)
+
+  const [sliderValue, setSliderValue] = useState<number>()
 
   const onStepperChange = (value: number) => {
     console.log('** START **')
@@ -109,7 +110,12 @@ export function App() {
                 />
                 <Stepper onChange={onStepperChange} />
 
-                <Slider onChange={(value) => setSliderValue(value)} />
+                <Slider
+                  hasTextbox={true}
+                  label={'Slider label'}
+                  value={sliderValue}
+                  onChange={(value) => setSliderValue(value)}
+                />
                 <div>Slider value: {sliderValue}</div>
 
                 <button type="submit">Submit</button>

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -52,7 +52,7 @@ export function Slider({
       return
     }
 
-    let percent: number = 0
+    let percent = 0
     if (sliderValue !== undefined)
       percent = ((sliderValue - min) / (max - min)) * 100
 

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -42,8 +42,8 @@ export function Slider({
   onChange,
 }: SliderProps) {
   const [background, setBackground] = React.useState<string>()
-  const [sliderValue, setSliderValue] = React.useState<number>(
-    value ?? defaultValue ?? 0
+  const [sliderValue, setSliderValue] = React.useState<number | undefined>(
+    value ?? defaultValue
   )
 
   React.useLayoutEffect(() => {
@@ -52,12 +52,17 @@ export function Slider({
       return
     }
 
-    const percent: number = ((sliderValue - min) / (max - min)) * 100
+    let percent: number = 0
+    if (sliderValue !== undefined)
+      percent = ((sliderValue - min) / (max - min)) * 100
+
     setBackground(getSliderTrackBackground(percent))
   }, [disabled, sliderValue])
 
   React.useEffect(() => {
-    setSliderValue(Number(value))
+    let numValue = Number(value)
+    if (Number.isNaN(numValue)) setSliderValue(undefined)
+    else setSliderValue(Number(value))
   }, [value])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -78,7 +83,7 @@ export function Slider({
             <InputWrapper unitLabel={unitLabel}>
               <input
                 type="number"
-                value={sliderValue}
+                value={sliderValue ?? ''}
                 id={`${name}-textbox`}
                 name={name}
                 className={errorMessage ? 'is-invalid' : ''}
@@ -91,7 +96,7 @@ export function Slider({
       )}
       <input
         type="range"
-        value={sliderValue}
+        value={sliderValue || 0}
         id={name}
         name={name}
         min={min}

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -59,16 +59,24 @@ export function Slider({
     setBackground(getSliderTrackBackground(percent))
   }, [disabled, sliderValue])
 
+  const setNumValueOrEmpty = (value: number | undefined | string) => {
+    let numValue: number | undefined = Number(value)
+
+    if (Number.isNaN(numValue) || value === '') numValue = undefined
+
+    setSliderValue(numValue)
+
+    return numValue
+  }
+
   React.useEffect(() => {
-    let numValue = Number(value)
-    if (Number.isNaN(numValue)) setSliderValue(undefined)
-    else setSliderValue(Number(value))
+    setNumValueOrEmpty(value)
   }, [value])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target
-    setSliderValue(Number(value))
-    if (onChange) onChange(Number(value))
+    const newVal = setNumValueOrEmpty(value)
+    if (onChange) onChange(newVal)
   }
 
   return (

--- a/libs/react/src/types/props/index.ts
+++ b/libs/react/src/types/props/index.ts
@@ -28,7 +28,7 @@ export interface SliderProps {
   hasTextbox?: boolean
   unitLabel?: string
   disabled?: boolean
-  onChange?: (value: number) => void
+  onChange?: (value: number | undefined) => void
 
   /**
    * @deprecated Use `value` instead


### PR DESCRIPTION
Allow setting `undefined` value on the React slider, both programatically and through the input fields.

Closes #865