### PR TITLE
fix(slider): emit `min` value when setting textbox to empty string

### DIFF
--- a/libs/react/src/lib/slider/slider.spec.tsx
+++ b/libs/react/src/lib/slider/slider.spec.tsx
@@ -54,4 +54,50 @@ describe('Slider', () => {
     fireEvent.change(input, { target: { value: 10 } })
     expect(onChange).toBeCalled()
   })
+
+  it('should clamp to max value', () => {
+    const { container, rerender } = render(<Slider />)
+    const input = container.querySelector('input') as HTMLInputElement
+    act(() => {
+      rerender(<Slider value={200} />)
+    })
+    expect(input.value).toBe('100')
+  })
+
+  it('should clamp to min value', () => {
+    const { container, rerender } = render(<Slider />)
+    const input = container.querySelector('input') as HTMLInputElement
+    act(() => {
+      rerender(<Slider value={-10} />)
+    })
+    expect(input.value).toBe('0')
+  })
+
+  it('should fire onClamp', () => {
+    const onClamp = jest.fn()
+    const { rerender } = render(<Slider onClamp={onClamp} />)
+    act(() => {
+      rerender(<Slider onClamp={onClamp} value={200} />)
+    })
+    expect(onClamp).toBeCalled()
+  })
+
+  it('should emit min value when input field is set to empty', () => {
+    const onChange = jest.fn()
+    const { container } = render(
+      <Slider
+        label={'label'}
+        hasTextbox={true}
+        value={50}
+        min={10}
+        max={60}
+        onChange={onChange}
+      />
+    )
+    const inputField = container.querySelector(
+      'input[type=number]'
+    ) as HTMLInputElement
+    fireEvent.blur(inputField, { target: { value: '' } })
+    expect(onChange).toBeCalledWith(10)
+  })
 })

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -65,23 +65,13 @@ export function Slider({
   }, [disabled, sliderValue])
 
   const clamp = (unclamped: number | undefined | string): number => {
-    if (!enableClamping || unclamped === undefined) return Number(unclamped)
+    if (!enableClamping) return Number(unclamped)
 
     if (!unclamped || Number.isNaN(unclamped)) return min
     if (typeof unclamped === 'string') unclamped = Number(unclamped)
 
-    let clamped = unclamped
-    let hasClamped = false
-
-    if (clamped < min) {
-      hasClamped = true
-      clamped = min
-    }
-    if (clamped > max) {
-      hasClamped = true
-      clamped = max
-    }
-    if (hasClamped && onClamp) onClamp(unclamped)
+    const clamped = Math.min(Math.max(min, unclamped), max)
+    if (clamped !== unclamped && onClamp) onClamp(unclamped)
 
     return clamped
   }

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -67,8 +67,8 @@ export function Slider({
   const clamp = (unclamped: number | undefined | string): number => {
     if (!enableClamping) return Number(unclamped)
 
-    if (!unclamped || Number.isNaN(unclamped)) return min
     if (typeof unclamped === 'string') unclamped = Number(unclamped)
+    if (!unclamped || Number.isNaN(unclamped)) return min
 
     const clamped = Math.min(Math.max(min, unclamped), max)
     if (clamped !== unclamped && onClamp) onClamp(unclamped)

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -64,26 +64,26 @@ export function Slider({
     setBackground(getSliderTrackBackground(percent))
   }, [disabled, sliderValue])
 
-  const clamp = (origValue: number | undefined | string): number => {
-    if (!enableClamping || origValue === undefined) return Number(origValue)
+  const clamp = (unclamped: number | undefined | string): number => {
+    if (!enableClamping || unclamped === undefined) return Number(unclamped)
 
-    if (!origValue || Number.isNaN(origValue)) return min
-    if (typeof origValue === 'string') origValue = Number(origValue)
+    if (!unclamped || Number.isNaN(unclamped)) return min
+    if (typeof unclamped === 'string') unclamped = Number(unclamped)
 
-    let newValue = origValue
+    let clamped = unclamped
     let hasClamped = false
 
-    if (newValue < min) {
+    if (clamped < min) {
       hasClamped = true
-      newValue = min
+      clamped = min
     }
-    if (newValue > max) {
+    if (clamped > max) {
       hasClamped = true
-      newValue = max
+      clamped = max
     }
-    if (hasClamped && onClamp) onClamp(origValue)
+    if (hasClamped && onClamp) onClamp(unclamped)
 
-    return newValue
+    return clamped
   }
 
   const setNumValue = (value: number | undefined | string) => {

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -6,7 +6,6 @@ import {
 } from '@sebgroup/extract'
 
 import { SliderProps } from '../../types'
-import { set } from 'date-fns'
 
 const InputWrapper = ({
   children,

--- a/libs/react/src/types/props/index.ts
+++ b/libs/react/src/types/props/index.ts
@@ -28,7 +28,7 @@ export interface SliderProps {
   hasTextbox?: boolean
   unitLabel?: string
   disabled?: boolean
-  onChange?: (value: number | undefined) => void
+  onChange?: (value: number) => void
   enableClamping?: boolean
   onClamp?: (value: number) => void
 


### PR DESCRIPTION
Also defer clamping of textbox value until focus moves away from the field or enter is pressed.

The slider will now only emit number values. If the user empties the text input field, the slider will emit its `min`-value (0 by default) through the `onChange`-callback.