### PR TITLE
fix: 🐛 Make wizard step card footer button show flex-start

### DIFF
--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -87,11 +87,15 @@
       padding: 1rem 1rem 1.5rem 4.5rem;
     }
   }
+
+  > footer {
+    justify-content: flex-start;
+  }
+  
   &__footer {
     border-top: 1px solid tokens.get(tokens.$grey, 500);
     padding: 1.5rem 1rem 1.5rem 1rem;
     margin-top: 0;
-    justify-content: flex-start;
 
     @include common.media-breakpoint-up('sm') {
       padding: 1.5rem 1rem 1.5rem 4.5rem;


### PR DESCRIPTION
The footer button in wizard step card is showing to the right side. 
This is because the card footer CSS is overriding the wizard step card footer CSS.

Scoped the wizard step card footer to show flex-start.

Before:
![image](https://github.com/sebgroup/green/assets/2648767/55352f84-4828-47b7-94e6-3bfbc7887c42)


After:
![image](https://github.com/sebgroup/green/assets/2648767/213bf3a7-16b4-46ff-8279-bd7ffdbef1e1)
