### PR TITLE
fix(icon-button): add missing type

### DIFF
--- a/libs/chlorophyll/scss/components/button/_index.scss
+++ b/libs/chlorophyll/scss/components/button/_index.scss
@@ -56,6 +56,7 @@ button[type='button']:where(
         .danger,
         .close,
         .link,
+        .icon,
         [aria-haspopup='listbox'],
         [aria-haspopup='menu']
       )

--- a/libs/react/src/lib/form/iconButton/iconButton.tsx
+++ b/libs/react/src/lib/form/iconButton/iconButton.tsx
@@ -1,7 +1,9 @@
 import { ReactNode, MouseEvent } from 'react'
+import { ButtonType } from '@sebgroup/extract'
 
 interface IconButtonInterface {
   children: ReactNode
+  type?: ButtonType
   onClick: (event: MouseEvent) => void
   'aria-expanded'?: boolean
   'aria-controls'?: string
@@ -14,6 +16,7 @@ const IconButton = ({ children, onClick, ...props }: IconButtonInterface) => {
       onClick={onClick}
       aria-controls={props['aria-controls']}
       aria-expanded={props['aria-expanded']}
+      type={props.type ?? 'button'}
     >
       {children}
     </button>


### PR DESCRIPTION
The type attribute was missing from the IconButton, meaning if the button was used inside a `<form>`, it would [act as a submit button by default](https://stackoverflow.com/a/9824845/12416767). This meant that the expandableInfo button would trigger submission of a form, instead of just toggling the expandable info.

Adding it as a optional property, which defaults to `button` not to cause any breaking changes.