### PR TITLE
fix: 🐛 Context menu on scroll markForCheck and css fixes

### DIFF
--- a/libs/angular/src/lib/context-menu/context-menu.component.html
+++ b/libs/angular/src/lib/context-menu/context-menu.component.html
@@ -1,6 +1,6 @@
 <button
   #contextMenuAnchor
-  class="ghost small"
+  class="ghost small small-padding-adjusted"
   [class.active]="isActive"
   (click)="open()"
 >

--- a/libs/angular/src/lib/context-menu/context-menu.component.html
+++ b/libs/angular/src/lib/context-menu/context-menu.component.html
@@ -1,6 +1,6 @@
 <button
   #contextMenuAnchor
-  class="ghost small small-padding-adjusted"
+  class="ghost small px-3"
   [class.active]="isActive"
   (click)="open()"
 >

--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   EventEmitter,
@@ -45,6 +46,7 @@ export class NggContextMenuComponent
   menuCloseSubscription?: Subscription
 
   constructor(
+    private changeDetectorRef: ChangeDetectorRef,
     private elementRef: ElementRef,
     @Optional()
     @Inject(ON_SCROLL_TOKEN)
@@ -103,6 +105,7 @@ export class NggContextMenuComponent
 
   close(): void {
     this.isActive = false
+    this.changeDetectorRef.markForCheck()
   }
 
   onItemClick(item: DropdownOption): void {

--- a/libs/chlorophyll/scss/components/context-menu/_index.scss
+++ b/libs/chlorophyll/scss/components/context-menu/_index.scss
@@ -19,7 +19,3 @@
     @include common.add-border-radius();
   }
 }
-
-.small-padding-adjusted {
-  padding: 0.4375rem 0.5rem !important;
-}

--- a/libs/chlorophyll/scss/components/context-menu/_index.scss
+++ b/libs/chlorophyll/scss/components/context-menu/_index.scss
@@ -5,6 +5,7 @@
 .popover-context-menu {
   @include common.media-breakpoint-up('sm') {
     @include mixins.add-context-menu();
+    border: none;
   }
 
   ul[role='listbox'] {
@@ -19,12 +20,6 @@
   }
 }
 
-.small {
+.small-padding-adjusted {
   padding: 0.4375rem 0.5rem !important;
-}
-
-@include common.media-breakpoint-up('sm') {
-  .popover {
-    border: none;
-  }
 }


### PR DESCRIPTION
Added markForCheck due to angular change detection not caching changes on scroll and improved css

BREAKING CHANGE: 🧨 -

✅ Closes: -