### PR TITLE
feat: 🎸 components can be added as tab content

### DIFF
--- a/libs/react/src/lib/tabs/tabs.spec.tsx
+++ b/libs/react/src/lib/tabs/tabs.spec.tsx
@@ -1,7 +1,60 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import Tabs, { Tab, TabProps } from './tabs'
+import Tabs, { IList, Tab } from './tabs'
 
-const list: TabProps[] = [
+
+const list: IList[] = [
+  { text: 'Page 1', href: '#' },
+  { text: 'Page 2', href: '#' },
+  { text: 'Page 3', href: '#' },
+  { text: 'Page 4', href: '#' },
+  { text: 'Page 5' },
+  { text: 'Page 6', disabled: true },
+]
+
+describe('Tabs only allow text as content', () => {
+  it('should render all anchor elements', () => {
+    render(<Tabs list={list}></Tabs>)
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    expect(anchorTag).toBeTruthy()
+    anchorTag?.map((tags, index) =>
+      expect(tags.textContent).toBe(list[index].text)
+    )
+  })
+
+  it('onClick changes selectedTab', () => {
+    render(<Tabs list={list}></Tabs>)
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    fireEvent.click(anchorTag[1])
+    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2')
+  })
+
+  it('OnClick should fire tabOnChange function', () => {
+    const onTabChange: jest.Mock = jest
+      .fn()
+      .mockImplementation((value: number) => value)
+    render(<Tabs list={list} onTabChange={onTabChange}></Tabs>)
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    fireEvent.click(anchorTag[1])
+    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2')
+    expect(onTabChange).toBeCalledWith(1)
+  })
+
+  it('Should have aria-disabled', () => {
+    render(<Tabs list={list} />)
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    expect(anchorTag[4].getAttribute('aria-disabled')).toBe(null)
+    expect(anchorTag[4].getAttribute('href')).toBe('#')
+    expect(anchorTag[5].getAttribute('aria-disabled')).toBe('true')
+  })
+
+  it('Should set href to "#" if href is not defined ', () => {
+    render(<Tabs list={list} />)
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    expect(anchorTag[4].getAttribute('href')).toBe('#')
+  })
+})
+
+const tabList: TabProps[] = [
   { title: 'Page 1', children: 'Page 1 Content' },
   { title: 'Page 2', children: 'Page 2 Content' },
   { title: 'Page 3', children: 'Page 3 Content' },
@@ -10,19 +63,19 @@ const list: TabProps[] = [
   { title: 'Page 6', disabled: true },
 ]
 
-describe('Tabs', () => {
+describe('Tabs allow components as content', () => {
   it('should render all anchor elements', () => {
-    render(<Tabs>{ list.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
+    render(<Tabs>{ tabList.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag).toBeTruthy()
     anchorTag?.forEach((tag, index) => {
-      expect(tag.textContent).toBe(list[index].title);
+      expect(tag.textContent).toBe(tabList[index].title);
     }  
     )
   })
 
   it('onClick changes selectedTab', () => {
-    render(<Tabs>{ list.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
+    render(<Tabs>{ tabList.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     fireEvent.click(anchorTag[1])
     expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2 Content')
@@ -32,7 +85,7 @@ describe('Tabs', () => {
     const onTabChange: jest.Mock = jest
       .fn()
       .mockImplementation((value: number) => value)
-    render(<Tabs onTabChange={onTabChange}>{ list.map(tab => <Tab {...tab}></Tab>)}</Tabs>)
+    render(<Tabs onTabChange={onTabChange}>{ tabList.map(tab => <Tab {...tab}></Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     fireEvent.click(anchorTag[1])
     expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2 Content')
@@ -40,7 +93,7 @@ describe('Tabs', () => {
   })
 
   it('Should have aria-disabled', () => {
-    render(<Tabs>{ list.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
+    render(<Tabs>{ tabList.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag[4].getAttribute('aria-disabled')).toBe(null)
     expect(anchorTag[4].getAttribute('href')).toBe('#')
@@ -48,7 +101,7 @@ describe('Tabs', () => {
   })
 
   it('Should set href to "#" if href is not defined ', () => {
-    render(<Tabs>{ list.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
+    render(<Tabs>{ tabList.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag[4].getAttribute('href')).toBe('#')
   })

--- a/libs/react/src/lib/tabs/tabs.spec.tsx
+++ b/libs/react/src/lib/tabs/tabs.spec.tsx
@@ -1,45 +1,46 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import Tabs, { IList } from './tabs'
+import Tabs, { Tab, TabProps } from './tabs'
 
-const list: IList[] = [
-  { text: 'Page 1', href: '#' },
-  { text: 'Page 2', href: '#' },
-  { text: 'Page 3', href: '#' },
-  { text: 'Page 4', href: '#' },
-  { text: 'Page 5' },
-  { text: 'Page 6', disabled: true },
+const list: TabProps[] = [
+  { title: 'Page 1', children: 'Page 1 Content' },
+  { title: 'Page 2', children: 'Page 2 Content' },
+  { title: 'Page 3', children: 'Page 3 Content' },
+  { title: 'Page 4', children: <div><div>Page 4 Content</div></div> },
+  { title: 'Page 5', children: <>Page 5 is a Component</> },
+  { title: 'Page 6', disabled: true },
 ]
 
 describe('Tabs', () => {
   it('should render all anchor elements', () => {
-    render(<Tabs list={list}></Tabs>)
+    render(<Tabs>{ list.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag).toBeTruthy()
-    anchorTag?.map((tags, index) =>
-      expect(tags.textContent).toBe(list[index].text)
+    anchorTag?.forEach((tag, index) => {
+      expect(tag.textContent).toBe(list[index].title);
+    }  
     )
   })
 
   it('onClick changes selectedTab', () => {
-    render(<Tabs list={list}></Tabs>)
+    render(<Tabs>{ list.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     fireEvent.click(anchorTag[1])
-    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2')
+    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2 Content')
   })
 
   it('OnClick should fire tabOnChange function', () => {
     const onTabChange: jest.Mock = jest
       .fn()
       .mockImplementation((value: number) => value)
-    render(<Tabs list={list} onTabChange={onTabChange}></Tabs>)
+    render(<Tabs onTabChange={onTabChange}>{ list.map(tab => <Tab {...tab}></Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     fireEvent.click(anchorTag[1])
-    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2')
+    expect(screen.getByRole('tabpanel').textContent).toEqual('Page 2 Content')
     expect(onTabChange).toBeCalledWith(1)
   })
 
   it('Should have aria-disabled', () => {
-    render(<Tabs list={list} />)
+    render(<Tabs>{ list.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag[4].getAttribute('aria-disabled')).toBe(null)
     expect(anchorTag[4].getAttribute('href')).toBe('#')
@@ -47,7 +48,7 @@ describe('Tabs', () => {
   })
 
   it('Should set href to "#" if href is not defined ', () => {
-    render(<Tabs list={list} />)
+    render(<Tabs>{ list.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
     expect(anchorTag[4].getAttribute('href')).toBe('#')
   })

--- a/libs/react/src/lib/tabs/tabs.stories.mdx
+++ b/libs/react/src/lib/tabs/tabs.stories.mdx
@@ -1,21 +1,35 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tabs, Tab } from './tabs'
+import { Tabs, Tab, Card } from '@sebgroup/green-react'
 
 export const Template = (children, ...props) => (
-  <Tabs
-   list={[
-      { text: 'Page 1', href: '#' },
-      { text: 'Page 2', href: '#' },
-      { text: 'Page 3', href: '#' },
-      { text: 'Page 4', href: '#' },
-      { text: 'Page 5', href: '#' },
-      { text: 'Page 6', href: '#' },
-    ]}
-    {...props}
-  />
+  <Card>
+    <Tabs {...props}>
+      <Tab title={'Page 1'}>Page 1 is simple text</Tab>
+      <Tab title={'Page 2'}>
+        <>
+          <h2>Page 2 is a component</h2>
+          <p>With more comlpex content</p>
+        </>
+      </Tab>
+      <Tab title={'Page 3'}>Page 3 Content</Tab>
+      <Tab title={'Page 4'}>
+        <>Page 4 Content</>
+      </Tab>
+    </Tabs>
+  </Card>
 )
 
 <Meta title="Components/Tabs" component={Tabs} />
+
+<Story
+  name="Tabs"
+  parameters={{
+    componentIds: ['component-tabs'],
+    docs: { disable: true },
+  }}
+>
+  {Template.bind({})}
+</Story>
 
 # Tabs
 
@@ -23,10 +37,14 @@ Tabs make it easy to explore and switch between different views or functional as
 
 <Canvas>
   <Tabs>
-    <Tab title={'Page 1'}>Page 1 is simple text</Tab> 
-    <Tab title={'Page 2'}><>Page 2 is a component</></Tab> 
-    <Tab title={'Page 3'}>Page 3 Content</Tab> 
-    <Tab title={'Page 4'}><>Page 4 Content</></Tab> 
+    <Tab title={'Page 1'}>Page 1 is simple text</Tab>
+    <Tab title={'Page 2'}>
+      <>Page 2 is a component</>
+    </Tab>
+    <Tab title={'Page 3'}>Page 3 Content</Tab>
+    <Tab title={'Page 4'}>
+      <>Page 4 Content</>
+    </Tab>
   </Tabs>
 </Canvas>
 
@@ -34,29 +52,22 @@ Tabs make it easy to explore and switch between different views or functional as
 
 <Canvas>
   <Tabs>
-    <Tab title={'Page 1'}>Page 1 Content</Tab> 
-    <Tab title={'Page 2'}>Page 2 Content</Tab> 
-    <Tab title={'Page 3'} disabled>Page 3 Content</Tab> 
-    <Tab title={'Page 4'} disabled>Page 4 Content</Tab> 
+    <Tab title={'Page 1'}>Page 1 Content</Tab>
+    <Tab title={'Page 2'}>Page 2 Content</Tab>
+    <Tab title={'Page 3'} disabled>
+      Page 3 Content
+    </Tab>
+    <Tab title={'Page 4'} disabled>
+      Page 4 Content
+    </Tab>
   </Tabs>
 </Canvas>
 
 <br />
 
-# Deprecated Tabs
-<Canvas>
-   <Tabs
-    list={[
-      { text: 'Page 1', href: '#' },
-      { text: 'Page 2', href: '#' },
-      { text: 'Page 3', href: '#' },
-      { text: 'Page 4', href: '#' },
-    ]}
-  />
-</Canvas>
+# Using `list` property _(deprecated)_
 
-
-#### Disabled tabs
+This interface only supports text content, and will be removed in a future release.
 
 <Canvas>
   <Tabs
@@ -71,21 +82,14 @@ Tabs make it easy to explore and switch between different views or functional as
   />
 </Canvas>
 
-<Story
-  name="Tabs"
-  parameters={{
-    componentIds: ['component-tabs']
-  }}
-  args={{ children: 'Test' }}>
-  {Template.bind({})}
-</Story>
-
 <br />
 
 #### Available props
+
 ##### Tabs
+
 <ArgsTable of={Tabs} />
 
 ##### Tab
-<ArgsTable of={Tab} />
 
+<ArgsTable of={Tab} />

--- a/libs/react/src/lib/tabs/tabs.stories.mdx
+++ b/libs/react/src/lib/tabs/tabs.stories.mdx
@@ -3,6 +3,14 @@ import { Tabs, Tab } from './tabs'
 
 export const Template = (children, ...props) => (
   <Tabs
+   list={[
+      { text: 'Page 1', href: '#' },
+      { text: 'Page 2', href: '#' },
+      { text: 'Page 3', href: '#' },
+      { text: 'Page 4', href: '#' },
+      { text: 'Page 5', href: '#' },
+      { text: 'Page 6', href: '#' },
+    ]}
     {...props}
   />
 )
@@ -22,7 +30,7 @@ Tabs make it easy to explore and switch between different views or functional as
   </Tabs>
 </Canvas>
 
-### Disabled tabs
+#### Disabled tabs
 
 <Canvas>
   <Tabs>
@@ -34,6 +42,34 @@ Tabs make it easy to explore and switch between different views or functional as
 </Canvas>
 
 <br />
+
+# Deprecated Tabs
+<Canvas>
+   <Tabs
+    list={[
+      { text: 'Page 1', href: '#' },
+      { text: 'Page 2', href: '#' },
+      { text: 'Page 3', href: '#' },
+      { text: 'Page 4', href: '#' },
+    ]}
+  />
+</Canvas>
+
+
+#### Disabled tabs
+
+<Canvas>
+  <Tabs
+    list={[
+      { text: 'Page 1', href: '#' },
+      { text: 'Page 2', href: '#' },
+      { text: 'Page 3', href: '#' },
+      { text: 'Page 4', href: '#' },
+      { text: 'Page 5', href: '#', disabled: true },
+      { text: 'Page 6', href: '#', disabled: true },
+    ]}
+  />
+</Canvas>
 
 <Story
   name="Tabs"

--- a/libs/react/src/lib/tabs/tabs.stories.mdx
+++ b/libs/react/src/lib/tabs/tabs.stories.mdx
@@ -1,16 +1,8 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import { Tabs } from './tabs'
+import { Tabs, Tab } from './tabs'
 
 export const Template = (children, ...props) => (
   <Tabs
-    list={[
-      { text: 'Page 1', href: '#' },
-      { text: 'Page 2', href: '#' },
-      { text: 'Page 3', href: '#' },
-      { text: 'Page 4', href: '#' },
-      { text: 'Page 5', href: '#' },
-      { text: 'Page 6', href: '#' },
-    ]}
     {...props}
   />
 )
@@ -22,32 +14,25 @@ export const Template = (children, ...props) => (
 Tabs make it easy to explore and switch between different views or functional aspects of an app or to browse categorized data sets.
 
 <Canvas>
-  <Tabs
-    list={[
-      { text: 'Page 1', href: '#' },
-      { text: 'Page 2', href: '#' },
-      { text: 'Page 3', href: '#' },
-      { text: 'Page 4', href: '#' },
-    ]}
-  />
+  <Tabs>
+    <Tab title={'Page 1'}>Page 1 is simple text</Tab> 
+    <Tab title={'Page 2'}><>Page 2 is a component</></Tab> 
+    <Tab title={'Page 3'}>Page 3 Content</Tab> 
+    <Tab title={'Page 4'}><>Page 4 Content</></Tab> 
+  </Tabs>
 </Canvas>
 
 ### Disabled tabs
 
 <Canvas>
-  <Tabs
-    list={[
-      { text: 'Page 1', href: '#' },
-      { text: 'Page 2', href: '#' },
-      { text: 'Page 3', href: '#' },
-      { text: 'Page 4', href: '#' },
-      { text: 'Page 5', href: '#', disabled: true },
-      { text: 'Page 6', href: '#', disabled: true },
-    ]}
-  />
+  <Tabs>
+    <Tab title={'Page 1'}>Page 1 Content</Tab> 
+    <Tab title={'Page 2'}>Page 2 Content</Tab> 
+    <Tab title={'Page 3'} disabled>Page 3 Content</Tab> 
+    <Tab title={'Page 4'} disabled>Page 4 Content</Tab> 
+  </Tabs>
 </Canvas>
 
-<hr />
 <br />
 
 <Story
@@ -60,8 +45,11 @@ Tabs make it easy to explore and switch between different views or functional as
 </Story>
 
 <br />
-<hr />
 
 #### Available props
-
+##### Tabs
 <ArgsTable of={Tabs} />
+
+##### Tab
+<ArgsTable of={Tab} />
+

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -17,7 +17,7 @@ interface TabsProps {
    */
   list?: IList[]
   onTabChange?: (index: number) => void
-  children?: ReactNode[] | ReactElement<TabProps>[]
+  children?: ReactElement<TabProps>[]
 }
 
 export interface TabProps {

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -13,6 +13,7 @@ export interface IList {
 
 interface TabsProps {
   /**
+   * **Deprecated**
    * @deprecated use `<Tab>` child components instead
    */
   list?: IList[]

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -1,8 +1,18 @@
 import React, { useState, ReactNode, ReactElement, PropsWithChildren  } from 'react'
 
-interface TabsProps  {
+/**
+ * @deprecated use `<Tab>` child components instead
+ */
+export interface IList {
+  text?: string
+  href?: string
+  disabled?: boolean
+}
+
+interface TabsProps {
+  list?: IList[]
   onTabChange?: (index: number) => void
-  children?: ReactElement<TabProps>[]
+  children?: ReactNode[] | ReactElement<TabProps>[]
 }
 
 export interface TabProps {
@@ -14,7 +24,7 @@ export interface TabProps {
 
 export const Tab = (props: PropsWithChildren<TabProps>) => null;
 
-export const Tabs = ({ onTabChange, children }: TabsProps) => {
+export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
   const [selectedTab, setSelectedTab] = useState(0)
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
@@ -29,7 +39,22 @@ export const Tabs = ({ onTabChange, children }: TabsProps) => {
   return (
     <>
       <nav role="tablist">
-        {children && children?.map((tab: ReactElement<TabProps>, index: number) => (
+        {
+          !children && list?.map((value: IList, index: number) => (
+            <a
+              href={value.disabled ? undefined : value.href || '#'}
+              onClick={onClick}
+              role="tab"
+              key={index}
+              data-index-number={index}
+              aria-disabled={value.disabled}
+              aria-selected={selectedTab === index}
+            >
+              {value.text}
+            </a>
+          ))
+        }
+        {children?.map((tab: ReactElement<TabProps>, index: number) => (
           <a
             href={tab.props.disabled ? undefined : tab.props.href || '#'}
             onClick={onClick}
@@ -45,6 +70,17 @@ export const Tabs = ({ onTabChange, children }: TabsProps) => {
       </nav>
       <section>
         {
+          !children && list?.map((value: IList, index: number) => (
+            <article
+              role="tabpanel"
+              key={index}
+              aria-hidden={selectedTab !== index}
+            >
+              {value.text}
+            </article>
+          ))
+        }
+        {
         children?.map((tab: ReactElement<TabProps>, index: number) => (
           <article
             role="tabpanel"
@@ -53,7 +89,8 @@ export const Tabs = ({ onTabChange, children }: TabsProps) => {
           >
           {tab.props.children}
           </article>
-        ))}
+        ))
+       }
       </section>
     </>
   )

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -1,8 +1,10 @@
-import React, { useState, ReactNode, ReactElement, PropsWithChildren  } from 'react'
+import React, {
+  useState,
+  ReactNode,
+  ReactElement,
+  PropsWithChildren,
+} from 'react'
 
-/**
- * @deprecated use `<Tab>` child components instead
- */
 export interface IList {
   text?: string
   href?: string
@@ -10,19 +12,22 @@ export interface IList {
 }
 
 interface TabsProps {
+  /**
+   * @deprecated use `<Tab>` child components instead
+   */
   list?: IList[]
   onTabChange?: (index: number) => void
   children?: ReactNode[] | ReactElement<TabProps>[]
 }
 
 export interface TabProps {
-  title: string;
-  disabled?: boolean;
-  href?: string;
-  children?: ReactNode;
+  title: string
+  disabled?: boolean
+  href?: string
+  children?: ReactNode
 }
 
-export const Tab = (props: PropsWithChildren<TabProps>) => null;
+export const Tab = (props: PropsWithChildren<TabProps>) => null
 
 export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
   const [selectedTab, setSelectedTab] = useState(0)
@@ -39,8 +44,8 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
   return (
     <>
       <nav role="tablist">
-        {
-          !children && list?.map((value: IList, index: number) => (
+        {!children &&
+          list?.map((value: IList, index: number) => (
             <a
               href={value.disabled ? undefined : value.href || '#'}
               onClick={onClick}
@@ -52,8 +57,7 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
             >
               {value.text}
             </a>
-          ))
-        }
+          ))}
         {children?.map((tab: ReactElement<TabProps>, index: number) => (
           <a
             href={tab.props.disabled ? undefined : tab.props.href || '#'}
@@ -64,13 +68,13 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
             aria-disabled={tab.props.disabled}
             aria-selected={selectedTab === index}
           >
-          {tab.props.title}
+            {tab.props.title}
           </a>
         ))}
       </nav>
       <section>
-        {
-          !children && list?.map((value: IList, index: number) => (
+        {!children &&
+          list?.map((value: IList, index: number) => (
             <article
               role="tabpanel"
               key={index}
@@ -78,19 +82,16 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
             >
               {value.text}
             </article>
-          ))
-        }
-        {
-        children?.map((tab: ReactElement<TabProps>, index: number) => (
+          ))}
+        {children?.map((tab: ReactElement<TabProps>, index: number) => (
           <article
             role="tabpanel"
             key={index}
             aria-hidden={selectedTab !== index}
           >
-          {tab.props.children}
+            {tab.props.children}
           </article>
-        ))
-       }
+        ))}
       </section>
     </>
   )

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -1,18 +1,20 @@
-import React, { useState, ReactNode } from 'react'
+import React, { useState, ReactNode, ReactElement, PropsWithChildren  } from 'react'
 
-export interface IList {
-  text?: string
-  href?: string
-  disabled?: boolean
-}
-
-interface TabsProps {
-  list?: IList[]
+interface TabsProps  {
   onTabChange?: (index: number) => void
-  children?: ReactNode[]
+  children?: ReactElement<TabProps>[]
 }
 
-export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
+export interface TabProps {
+  title: string;
+  disabled?: boolean;
+  href?: string;
+  children?: ReactNode;
+}
+
+export const Tab = (props: PropsWithChildren<TabProps>) => null;
+
+export const Tabs = ({ onTabChange, children }: TabsProps) => {
   const [selectedTab, setSelectedTab] = useState(0)
   const onClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault()
@@ -27,28 +29,29 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
   return (
     <>
       <nav role="tablist">
-        {list?.map((value: IList, index: number) => (
+        {children && children?.map((tab: ReactElement<TabProps>, index: number) => (
           <a
-            href={value.disabled ? undefined : value.href || '#'}
+            href={tab.props.disabled ? undefined : tab.props.href || '#'}
             onClick={onClick}
             role="tab"
             key={index}
             data-index-number={index}
-            aria-disabled={value.disabled}
+            aria-disabled={tab.props.disabled}
             aria-selected={selectedTab === index}
           >
-            {value.text}
+          {tab.props.title}
           </a>
         ))}
       </nav>
       <section>
-        {list?.map((value: IList, index: number) => (
+        {
+        children?.map((tab: ReactElement<TabProps>, index: number) => (
           <article
             role="tabpanel"
             key={index}
             aria-hidden={selectedTab !== index}
           >
-            {value.text}
+          {tab.props.children}
           </article>
         ))}
       </section>


### PR DESCRIPTION
Currently tabs only do not allow any content other than text. Second issue, the tab content and tab title are always equal. Now the tabs component allows adding tab children  components with any type of content

BREAKING CHANGE: 🧨 Tabs component now takes Tab child components as children.

✅ Closes:  #373