### PR TITLE
perf: ⚡️ only renders tab content when tab is selected

### DIFF
--- a/libs/react/src/lib/tabs/tabs.spec.tsx
+++ b/libs/react/src/lib/tabs/tabs.spec.tsx
@@ -74,6 +74,29 @@ describe('Tabs allow components as content', () => {
     )
   })
 
+  it('should only render the selected tab element', () => {
+    render(<Tabs>{ tabList.map(tab => <Tab {...tab}>{tab.children}</Tab>)}</Tabs>)
+    const tabsContent: HTMLElement[] = screen.getAllByRole('tabpanel', { hidden: true})
+    const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')
+    
+    expect(anchorTag).toBeTruthy()
+    expect(tabsContent.length).toEqual(6) 
+    expect(tabsContent[0].textContent).toBe(tabList[0].children);
+    tabsContent?.forEach((tab, index) => {
+      if(index !== 0)
+        expect(tab.textContent).toBe("");
+    })
+    const clickedTab = 2
+    fireEvent.click(anchorTag[clickedTab])
+    expect(tabsContent[clickedTab].textContent).toBe(tabList[clickedTab].children);
+
+    tabsContent?.forEach((tab, index) => {
+      if(index !== clickedTab)
+        expect(tab.textContent).toBe("");
+    }  
+    )
+  })
+
   it('onClick changes selectedTab', () => {
     render(<Tabs>{ tabList.map(tab => <Tab title={tab.title}>{tab.children}</Tab>)}</Tabs>)
     const anchorTag: HTMLAnchorElement[] = screen.getAllByRole('tab')

--- a/libs/react/src/lib/tabs/tabs.stories.mdx
+++ b/libs/react/src/lib/tabs/tabs.stories.mdx
@@ -41,7 +41,7 @@ Tabs make it easy to explore and switch between different views or functional as
       <>
         <p>Tab content will only render when a tab is selected.</p>
         <p>
-          If you need to pre-load data, do separately outside of the component
+          If you need to pre-load data, do it separately outside of the component
           that is rendered in the tab.
         </p>
       </>

--- a/libs/react/src/lib/tabs/tabs.stories.mdx
+++ b/libs/react/src/lib/tabs/tabs.stories.mdx
@@ -37,7 +37,15 @@ Tabs make it easy to explore and switch between different views or functional as
 
 <Canvas>
   <Tabs>
-    <Tab title={'Page 1'}>Page 1 is simple text</Tab>
+    <Tab title={'Page 1'}>
+      <>
+        <p>Tab content will only render when a tab is selected.</p>
+        <p>
+          If you need to pre-load data, do separately outside of the component
+          that is rendered in the tab.
+        </p>
+      </>
+    </Tab>
     <Tab title={'Page 2'}>
       <>Page 2 is a component</>
     </Tab>

--- a/libs/react/src/lib/tabs/tabs.tsx
+++ b/libs/react/src/lib/tabs/tabs.tsx
@@ -90,7 +90,7 @@ export const Tabs = ({ list, onTabChange, children }: TabsProps) => {
             key={index}
             aria-hidden={selectedTab !== index}
           >
-            {tab.props.children}
+             {selectedTab === index && tab.props.children}
           </article>
         ))}
       </section>


### PR DESCRIPTION
When tabs have components making network calls or any heavy processing, it might be ideal to delay this processing until the user has selected that tab. In most cases with tabs, users will not be clicking aroound eveyry tab all the time and so loading such content creates unnecessary overhead

BREAKING CHANGE: 🧨 None

✅ Closes: #904