### PR TITLE
feat(expandable-form-info): allow custom expandable content

### DIFF
--- a/apps/react-lib-dev/src/app/app.tsx
+++ b/apps/react-lib-dev/src/app/app.tsx
@@ -1,142 +1,30 @@
-import {
-  Navbar,
-  Dropdown,
-  RadioGroup,
-  RadioButton,
-  Form,
-  FormItems,
-  Button,
-  Stepper,
-  TextInput,
-  Datepicker,
-  Alert,
-  Slider,
-} from '@sebgroup/green-react'
+import { Navbar, Tabs, Tab } from '@sebgroup/green-react'
 import { useState } from 'react'
 import { IValidator } from '@sebgroup/extract'
-
-const dropDownKeyValueArray = [
-  {
-    label: 'Apple',
-    value: 'apple',
-  },
-  {
-    label: 'Banana',
-    value: 'banana',
-  },
-]
+import { FormExample } from './form'
 
 export function App() {
-  const [validator, setValidator] = useState<undefined | IValidator>(undefined)
-
-  const [adults, setAdults] = useState<{ id: number; value: number }>()
-
-  const [sliderValue, setSliderValue] = useState<number>()
-
-  const onStepperChange = (value: number) => {
-    console.log('** START **')
-    console.log('value:', value)
-    setAdults({
-      value,
-      id: 45,
-    })
-    console.log('adults:', adults)
-    console.log('** END **')
-  }
-
   return (
-    <>
-      <div className="use-green">
-        <Navbar title="Green React Dev" />
-        <Alert type={'warning'} isCloseable={false}>
-          This is my alert
-        </Alert>
-        <div className="container">
-          <div className="row">
-            <div className="col">
-              <h1>This is a form</h1>
-              <p>
-                If you are developing a React app this is a great form to work
-                on.
-              </p>
-              <Form onFormSubmit={(value) => console.log(value)}>
-                <Button
-                  onClick={() => {
-                    setValidator((prevState) =>
-                      prevState
-                        ? undefined
-                        : {
-                            message: 'This field is required',
-                            indicator: 'error',
-                            rules: { type: 'Required' },
-                          }
-                    )
-                  }}
-                >
-                  Change validation
-                </Button>
-                <Dropdown
-                  id={'my-dropdown'}
-                  options={dropDownKeyValueArray}
-                  validator={validator}
-                  onChange={console.log}
-                />
-                <Datepicker
-                  onChange={(date) => console.log('Selected date: ', date)}
-                />
-                <FormItems
-                  name="radio"
-                  validate={{
-                    message: 'Required',
-                    indicator: 'error',
-                    rules: { type: 'Required' },
-                  }}
-                >
-                  <RadioGroup
-                    label="Radio Group"
-                    onChange={(value) => console.log(value)}
-                  >
-                    <RadioButton label={'Fusilli'} value={'fusilli'} />
-                    <RadioButton label={'Penne'} value={'penne'} />
-                    <RadioButton label={'Farfalle'} value={'farfalle'} />
-                  </RadioGroup>
-                </FormItems>
-                <TextInput
-                  label={'Label'}
-                  info={
-                    'This is some information about the thing that gets longer if i say so'
-                  }
-                  validator={validator}
-                />
-                <Stepper onChange={onStepperChange} />
-
-                <Slider
-                  hasTextbox={true}
-                  label={'Slider label'}
-                  value={sliderValue}
-                  onChange={(value) => setSliderValue(value)}
-                  onClamp={(value) => {
-                    console.log('onClampValue', value)
-                  }}
-                />
-                <div>Slider value: {sliderValue}</div>
-
-                <button type="submit">Submit</button>
-              </Form>
-            </div>
+    <div className="use-green">
+      <Navbar title="Green React Dev" />
+      <div className="container">
+        <div className="row">
+          <div className="col">
+            <h1>React sample app</h1>
+            <Tabs>
+              <Tab title={'Form'}>
+                <div className="pt-5">
+                  <FormExample />
+                </div>
+              </Tab>
+              <Tab title={'Other'}>
+                <div className="pt-5">Hello</div>
+              </Tab>
+            </Tabs>
           </div>
         </div>
       </div>
-      <div>
-        <span>Outside Green</span>
-        <div
-          className="popover"
-          style={{ border: '2px solid grey', padding: 15, background: 'red' }}
-        >
-          This is a popper
-        </div>
-      </div>
-    </>
+    </div>
   )
 }
 

--- a/apps/react-lib-dev/src/app/form.tsx
+++ b/apps/react-lib-dev/src/app/form.tsx
@@ -1,0 +1,138 @@
+import { IValidator } from '@sebgroup/extract'
+import React from 'react'
+
+import {
+  Dropdown,
+  RadioGroup,
+  RadioButton,
+  Form,
+  FormItems,
+  Button,
+  Stepper,
+  TextInput,
+  Datepicker,
+  Slider,
+} from '@sebgroup/green-react'
+
+const dropDownKeyValueArray = [
+  {
+    label: 'Apple',
+    value: 'apple',
+  },
+  {
+    label: 'Banana',
+    value: 'banana',
+  },
+]
+
+export const FormExample = () => {
+  const [validator, setValidator] = React.useState<undefined | IValidator>(
+    undefined
+  )
+
+  const [adults, setAdults] = React.useState<{ id: number; value: number }>()
+
+  const [sliderValue, setSliderValue] = React.useState<number>()
+
+  const onStepperChange = (value: number) => {
+    console.log('** START **')
+    console.log('value:', value)
+    setAdults({
+      value,
+      id: 45,
+    })
+    console.log('adults:', adults)
+    console.log('** END **')
+  }
+
+  const toggleValidation = () => {
+    setValidator((prevState) =>
+      prevState
+        ? undefined
+        : {
+            message: 'This field is required',
+            indicator: 'error',
+            rules: { type: 'Required' },
+          }
+    )
+  }
+
+  return (
+    <>
+      <h2>This is a form</h2>
+      <p>If you are developing a React app this is a great form to work on.</p>
+
+      <Form onFormSubmit={(value) => console.log(value)}>
+        <Dropdown
+          label={'Select a fruit'}
+          id={'my-dropdown'}
+          options={dropDownKeyValueArray}
+          validator={validator}
+          onChange={console.log}
+        />
+
+        <Datepicker onChange={(date) => console.log('Selected date: ', date)} />
+
+        <FormItems
+          name="radio"
+          validate={{
+            message: 'Required',
+            indicator: 'error',
+            rules: { type: 'Required' },
+          }}
+        >
+          <RadioGroup
+            label="Radio Group"
+            onChange={(value) => console.log(value)}
+          >
+            <RadioButton label={'Fusilli'} value={'fusilli'} />
+            <RadioButton label={'Penne'} value={'penne'} />
+            <RadioButton label={'Farfalle'} value={'farfalle'} />
+          </RadioGroup>
+        </FormItems>
+
+        <TextInput
+          label={'Label'}
+          info={
+            'This is some information about the thing that gets longer if i say so'
+          }
+          expandableInfo="Expandable plain text information"
+          validator={validator}
+        />
+
+        <TextInput
+          label={'Label'}
+          info={
+            'This is some information about the thing that gets longer if i say so'
+          }
+          expandableInfo={
+            <>
+              <p>
+                React component in <b>Expandable Information</b>. Allows custom
+                markup, including <a href="#">links</a>
+              </p>
+              <p>Use sparingly!</p>
+            </>
+          }
+          validator={validator}
+        />
+
+        <Stepper onChange={onStepperChange} />
+
+        <Slider
+          hasTextbox={true}
+          label={'Slider label'}
+          value={sliderValue}
+          onChange={(value) => setSliderValue(value)}
+          onClamp={(value) => {
+            console.log('onClampValue', value)
+          }}
+        />
+        <div>Slider value: {sliderValue}</div>
+
+        <Button onClick={toggleValidation}>Toggle validation</Button>
+        <Button type="submit">Submit</Button>
+      </Form>
+    </>
+  )
+}

--- a/libs/chlorophyll/scss/components/link/_index.scss
+++ b/libs/chlorophyll/scss/components/link/_index.scss
@@ -36,19 +36,18 @@ Specify style on hover only
     // Do the style here
   }
 
-Enable Text smoothing 
+Enable Text smoothing
   -webkit-font-smoothing: antialiased;
   -webkit-text-size-adjust: 100%;
   text-rendering: optimizeLegibility;
 
 */
 
-
 // TODO: maybe move elsewhere?
 @each $variant, $colors in mixins.$variants {
   [class*='-#{$variant}'] {
     @include mixins.variant(
-      map.get($colors, 'color'),
+      currentColor,
       rgba(map.get($colors, 'fadable-color'), mixins.$outline-opacity)
     );
   }

--- a/libs/chlorophyll/scss/components/link/_mixins.scss
+++ b/libs/chlorophyll/scss/components/link/_mixins.scss
@@ -138,7 +138,6 @@ Base on background color of parent element eg. white links on dark backgrounds e
   }
   a:link:not(.button, [aria-disabled]) {
     color: $color;
-    text-decoration: none;
     &:hover,
     &:focus,
     &:visited {

--- a/libs/react/src/lib/form/input/input.tsx
+++ b/libs/react/src/lib/form/input/input.tsx
@@ -18,7 +18,7 @@ export type Renderer = (
   label?: string,
   info?: string,
   validator?: IValidator,
-  expandableInfo?: string,
+  expandableInfo?: React.ReactNode,
   expandableInfoButtonLabel?: string,
   testId?: string
 ) => JSX.Element

--- a/libs/react/src/lib/form/types.ts
+++ b/libs/react/src/lib/form/types.ts
@@ -1,12 +1,12 @@
 import { IValidator } from '@sebgroup/extract'
-import { HTMLProps } from 'react'
+import React, { HTMLProps } from 'react'
 
 export interface TextInputProps extends HTMLProps<HTMLInputElement> {
   type?: 'text' | 'email' | 'number'
   label?: string
   info?: string
   testId?: string
-  expandableInfo?: string
+  expandableInfo?: React.ReactNode
   expandableInfoButtonLabel?: string
   validator?: IValidator
   onChangeInput?: (value: string) => string
@@ -17,7 +17,7 @@ export interface NumberInputProps extends TextInputProps {
   min?: number
   max?: number
   step?: number
-  expandableInfo?: string
+  expandableInfo?: React.ReactNode
   expandableInfoButtonLabel?: string
 }
 

--- a/libs/react/src/lib/formItem/formItem.stories.mdx
+++ b/libs/react/src/lib/formItem/formItem.stories.mdx
@@ -1,15 +1,21 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs'
-import {FormItem} from "./formItem";
-import {Select, Option} from "../select";
+import { FormItem } from './formItem'
+import { Select, Option } from '../select'
 
 export const Template = () => {
   return (
     <>
-      <Select label="This is a label" labelInformation="this is information label">
+      <Select
+        label="This is a label"
+        labelInformation="this is information label"
+      >
         <Option>This is an option</Option>
         <Option>This is an option</Option>
       </Select>
-      <Select label="This is a label" labelInformation="this is information label">
+      <Select
+        label="This is a label"
+        labelInformation="this is information label"
+      >
         <Option>This is an option</Option>
         <Option>This is an option</Option>
       </Select>
@@ -19,14 +25,13 @@ export const Template = () => {
 
 <Meta title="Components/FormItem" component={FormItem} />
 
-
 # FormItem
 
 <Canvas>
   <Story
     name="TextInput"
     parameters={{
-      componentIds: ['component-input']
+      componentIds: ['component-input'],
     }}
     args={{ label: 'Text input', info: 'Input some text here' }}
   >
@@ -42,6 +47,24 @@ export const Template = () => {
       label="Hur mycket vill du låna?"
       info="För att du ska kunna få låna pengar behöver vi veta hur mycket"
       expandableInfo="This is some expandable information that is very long as was created that way in order to test how it preforms in such a situation"
+      expandableInfoButtonLabel="Toggle additional information"
+    />
+  </Story>
+</Canvas>
+
+Expandable information can also be used with JSX:
+
+<Canvas>
+  <Story name="Expandable information">
+    <NumberInput
+      label="Hur mycket vill du låna?"
+      info="För att du ska kunna få låna pengar behöver vi veta hur mycket"
+      expandableInfo={
+        <>
+          Using JSX here is useful if you need to include for example a
+          <a href="#">link</a>
+        </>
+      }
       expandableInfoButtonLabel="Toggle additional information"
     />
   </Story>

--- a/libs/react/src/lib/formItem/formItem.stories.mdx
+++ b/libs/react/src/lib/formItem/formItem.stories.mdx
@@ -55,7 +55,7 @@ export const Template = () => {
 Expandable information can also be used with JSX:
 
 <Canvas>
-  <Story name="Expandable information">
+  <Story name="Expandable information JSX">
     <NumberInput
       label="Hur mycket vill du låna?"
       info="För att du ska kunna få låna pengar behöver vi veta hur mycket"

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -22,7 +22,7 @@ interface FormItemProps {
   label?: string
   labelInformation?: string
   validator?: IValidator
-  expandableInfo?: string
+  expandableInfo?: React.ReactNode
   inputId?: string
   children: ReactNode
   expandableInfoButtonLabel?: string


### PR DESCRIPTION
This Pull Request changes the `expandableInfo` field on Input components to accept any React node instead of only strings. This means that any React rendered markup will be allowed in the field. Useful for adding links for example. Use with care!

Actually, this was already possible when not using Typescript, since the only difference is that the *type* of the prop has changed from `string` to `React.ReactNode`.