### PR TITLE
feat: 🎸 new input to set fixed placment of dropdown options

### DIFF
--- a/libs/angular/src/lib/dropdown/documentation.mdx
+++ b/libs/angular/src/lib/dropdown/documentation.mdx
@@ -79,10 +79,11 @@ Set an initial value by assigning the `value` to the value input or form control
 
 By default, the dropdown will look for a label and value pair for the data. The following inputs can be set to alter the options if neccesary.
 
-| Input (attribute) | Description                                                          | Default |
-| :---------------- | :------------------------------------------------------------------- | :------ |
-| useValue          | Which key to use as value.                                           | `value` |
-| display           | Which key to use as display value when selected and in options list. | `label` |
+| Input (attribute) | Description                                                                           | Default     |
+| :---------------- | :------------------------------------------------------------------------------------ | :---------- |
+| useValue          | Which key to use as value.                                                            | `value`     |
+| display           | Which key to use as display value when selected and in options list.                  | `label`     |
+| fixedPlacement?   | Fixed placement of the options list in the view: `bottom-start` or `top-start`. Passing a value to this attribute would prevent the default _flipping_ behavior of the element. | `undefined` |
 
 The value does not have to be a primitive value, it can be assigned an object but it requires that a `compareWith` function is provided to uniquely identify each object. Eg:
 

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -28,6 +28,7 @@ import {
   DropdownHandler,
   DropdownOption,
   DropdownOptionElement,
+  DropdownPlacements,
   DropdownTexts,
   dropdownValues,
   ElementProps,
@@ -62,6 +63,7 @@ export class NggDropdownComponent
   @Input() invalid?: boolean
   @Input() compareWith?: CompareWith
   @Input() searchFilter?: SearchFilter
+  @Input() fixedPlacement?: DropdownPlacements
 
   @Input() set multiSelect(value: string | boolean) {
     this._multiSelect = this.convertToBoolean(value)
@@ -140,7 +142,8 @@ export class NggDropdownComponent
         },
         (value) => {
           this.updateValue(value)
-        }
+        },
+        this.fixedPlacement
       )
     }
   }

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -227,8 +227,6 @@ const pop = (
       })
     }
 
-    console.log(_popperModifiers)
-
     handler.popper = createPopper(handler.toggler, handler.listbox, {
       placement: fixedPlacement ?? 'bottom-start',
       modifiers: _popperModifiers,

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -222,7 +222,9 @@ const pop = (
       _popperModifiers.push({
         name: 'flip',
         options: {
-          allowedAutoPlacements: [],
+          fallbackPlacements: [],
+          flipVariations: false,
+          allowedAutoPlacements: [fixedPlacement],
         },
       })
     }

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -28,13 +28,16 @@ import { isMobileViewport$ } from '../common/viewport-size'
 import { getOptionScrollPosition } from './helper-functions'
 import { IValidator } from '../helperFunction'
 
+export type DropdownPlacements = 'bottom-start' | 'top-start'
+
 export const createDropdown = (
   init: DropdownArgs,
   toggler: HTMLElement,
   listbox: HTMLElement,
   fieldset: HTMLElement | undefined = undefined,
   listener: DropdownListener,
-  onChange: OnChange
+  onChange: OnChange,
+  fixedPlacement?: DropdownPlacements
 ): DropdownHandler => {
   const handler: DropdownHandler = {
     toggler,
@@ -130,7 +133,7 @@ export const createDropdown = (
     .pipe(takeUntil(handler.onDestroy$))
     .subscribe((isMobile) => {
       lockBodyScroll(handler, isMobile)
-      pop(handler, listener, isMobile)
+      pop(handler, listener, isMobile, fixedPlacement)
     })
 
   handler.destroy = () => {
@@ -197,7 +200,8 @@ const update = async (
 const pop = (
   handler: DropdownHandler,
   listener: DropdownListener,
-  isMobile: boolean
+  isMobile: boolean,
+  fixedPlacement?: DropdownPlacements
 ) => {
   if (isMobile && handler.popper) {
     handler.popper.destroy()
@@ -205,16 +209,29 @@ const pop = (
 
     update(handler, listener, popper(handler.dropdown))
   } else if (!isMobile && !handler.popper) {
-    handler.popper = createPopper(handler.toggler, handler.listbox, {
-      placement: 'bottom-start',
-      modifiers: [
-        {
-          name: 'offset',
-          options: {
-            offset: [0, 4],
-          },
+    const _popperModifiers: Array<{ name: string; options: any }> = [
+      {
+        name: 'offset',
+        options: {
+          offset: [0, 4],
         },
-      ],
+      },
+    ]
+
+    if (!!fixedPlacement) {
+      _popperModifiers.push({
+        name: 'flip',
+        options: {
+          allowedAutoPlacements: [],
+        },
+      })
+    }
+
+    console.log(_popperModifiers);
+
+    handler.popper = createPopper(handler.toggler, handler.listbox, {
+      placement: fixedPlacement ?? 'bottom-start',
+      modifiers: _popperModifiers,
     })
 
     update(handler, listener, handler.dropdown)

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -227,8 +227,6 @@ const pop = (
       })
     }
 
-    console.log(_popperModifiers);
-
     handler.popper = createPopper(handler.toggler, handler.listbox, {
       placement: fixedPlacement ?? 'bottom-start',
       modifiers: _popperModifiers,

--- a/libs/extract/src/lib/dropdown/dropdown.ts
+++ b/libs/extract/src/lib/dropdown/dropdown.ts
@@ -218,7 +218,7 @@ const pop = (
       },
     ]
 
-    if (!!fixedPlacement) {
+    if (fixedPlacement) {
       _popperModifiers.push({
         name: 'flip',
         options: {
@@ -226,6 +226,8 @@ const pop = (
         },
       })
     }
+
+    console.log(_popperModifiers)
 
     handler.popper = createPopper(handler.toggler, handler.listbox, {
       placement: fixedPlacement ?? 'bottom-start',


### PR DESCRIPTION
### Issue
There is a case where we need the dropdown options to be fixed at the top and not flip to the bottom (flipping to the bottom _cuts_ the dropdown options below):

![Media2](https://github.com/sebgroup/green/assets/82629695/7cc28657-3cb9-4ac2-be97-7cd017d731a8)

### Fix
Add a new attribute to accept whether the dropdown options placement should be fixed either at the top or the bottom.
i.e., passing "top-start" would fix the options at the top and disable the flipping:

![image](https://github.com/sebgroup/green/assets/82629695/1e84a2cb-6754-4e71-87bd-2bcffde94354)
