### PR TITLE
fix(dropdown): don't treat `0` as a falsy option value

### DIFF
--- a/libs/extract/src/lib/dropdown/reducers.ts
+++ b/libs/extract/src/lib/dropdown/reducers.ts
@@ -242,7 +242,7 @@ export const selectByValue = (
   selection?: any
 ): AbstractDropdown => {
   const isSelected = (value1: any) => {
-    if (!selection) {
+    if (!selection && typeof selection !== 'number') {
       return false
     } else if (dropdown.isMultiSelect && Array.isArray(selection)) {
       return selection.some((value2) => dropdown.compareWith(value1, value2))


### PR DESCRIPTION
fix dropdown options then values is numeric starting from 0 which is falsy value, and currently prevents optio nvalue to be selected

BREAKING CHANGE:  -

✅ Closes: -