### PR TITLE
fix: 🐛 add onchange support to form items component

### DIFF
--- a/libs/react/src/lib/form/formItems.spec.tsx
+++ b/libs/react/src/lib/form/formItems.spec.tsx
@@ -1,9 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { FormItems, TextInput } from '.'
 import * as FormContext from './formContext'
 
 describe('FormItems Component', () => {
-  const mockFormContext: jest.SpyInstance = jest.spyOn(FormContext, 'useFormContext')
+  const mockFormContext: jest.SpyInstance = jest.spyOn(
+    FormContext,
+    'useFormContext'
+  )
 
   beforeEach(() => {
     mockFormContext.mockImplementation(() => ({
@@ -41,5 +45,19 @@ describe('FormItems Component', () => {
       target: { value: 'new value' },
     })
     expect(mockFn).toBeCalledTimes(2)
+  })
+
+  it('Should propagate onChange event to callback when provided', async () => {
+    const inputText = 'new value'
+    const user = userEvent.setup()
+    const mockFn: jest.Mock = jest.fn()
+    render(
+      <FormItems name="text" onChange={mockFn}>
+        <TextInput label="Some field" />
+      </FormItems>
+    )
+    expect(mockFn).not.toBeCalled()
+    await user.type(screen.getByRole('textbox'), inputText)
+    expect(mockFn).toBeCalledTimes(inputText.length)
   })
 })

--- a/libs/react/src/lib/form/formItems.tsx
+++ b/libs/react/src/lib/form/formItems.tsx
@@ -81,7 +81,7 @@ export const FormItems: React.FC<FormItemsProps> = ({
     name,
     onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
       if (typeof _onFormItemsChanged === 'function') {
-        _onFormItemsChanged?.(event)
+        _onFormItemsChanged(event)
       }
 
       onChange(event)

--- a/libs/react/src/lib/form/formItems.tsx
+++ b/libs/react/src/lib/form/formItems.tsx
@@ -5,11 +5,17 @@ import { validateInputValue } from './validateInput'
 
 export interface FormItemsProps {
   children: React.ReactNode
-  validate?: IValidator
   name: string
+  validate?: IValidator
+  onChange?: React.ChangeEventHandler<HTMLInputElement>
 }
 
-export const FormItems: React.FC<FormItemsProps> = ({ children, validate, name }) => {
+export const FormItems: React.FC<FormItemsProps> = ({
+  children,
+  name,
+  validate,
+  onChange: _onFormItemsChanged,
+}) => {
   const { setValues, setErrors, setFields, errors } = useFormContext()
 
   React.useEffect(() => {
@@ -35,11 +41,10 @@ export const FormItems: React.FC<FormItemsProps> = ({ children, validate, name }
       /* eslint-disable-next-line */
       setErrors((errors: Record<string, any>) => removeValues(errors))
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const onChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-
     if (!event.target) return
 
     const { value, name, type, checked } = event.target
@@ -48,21 +53,39 @@ export const FormItems: React.FC<FormItemsProps> = ({ children, validate, name }
     if (type === 'checkbox') {
       inputValue = checked ? value : null
       /* eslint-disable-next-line */
-      checked ? setValues((values: Record<string, any>) => ({ ...values, [name]: value })) : setValues((values: Record<string, any>) => ({ ...values, [name]: null }))
+      checked
+        ? setValues((values: Record<string, any>) => ({
+            ...values,
+            [name]: value,
+          }))
+        : setValues((values: Record<string, any>) => ({
+            ...values,
+            [name]: null,
+          }))
     } else {
       inputValue = value
       /* eslint-disable-next-line */
       setValues((values: Record<string, any>) => ({ ...values, [name]: value }))
     }
 
-    validateInputValue({ value: inputValue as string, name, type, checked }, validate?.rules as ValidatorRules, setErrors)
+    validateInputValue(
+      { value: inputValue as string, name, type, checked },
+      validate?.rules as ValidatorRules,
+      setErrors
+    )
   }
 
   /* eslint-disable-next-line */
-  return React.cloneElement(children as any, {
+  return React.cloneElement(children as React.ReactElement, {
     validator: errors?.[name] && validate,
     name,
-    onChange,
+    onChange: (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (typeof _onFormItemsChanged === 'function') {
+        _onFormItemsChanged?.(event)
+      }
+
+      onChange(event)
+    },
   })
 }
 


### PR DESCRIPTION
provide an alternative method for form context consumer to handle input change event in addition to the existing of `onFormSubmit` handler that is only trigger upon form submission