### PR TITLE
fix(dropdown): increase default z-index of popover

### DIFF
--- a/libs/chlorophyll/scss/components/themes/_mixins.scss
+++ b/libs/chlorophyll/scss/components/themes/_mixins.scss
@@ -147,7 +147,7 @@ Values for light mode are used by default.
   $backdrop-opacity: 0.5,
   $z-index-dropdown-backdrop: 990,
   $z-index-datepicker: 995,
-  $z-index-dropdown: 1000,
+  $z-index-dropdown: 2000,
   $z-index-sticky: 1020,
   $z-index-fixed: 1030,
   $z-index-modal-backdrop: 1040,

--- a/libs/chlorophyll/scss/tokens/_shame.scss
+++ b/libs/chlorophyll/scss/tokens/_shame.scss
@@ -58,7 +58,7 @@ $font-path: '../fonts' !default;
 // z-index values for managing depth
 // based on what we have and use in bootstrap today
 $zindex-dropdown-backdrop: 990;
-$zindex-dropdown: 1000;
+$zindex-dropdown: 2000;
 $zindex-sticky: 1020;
 $zindex-fixed: 1030;
 $zindex-modal-backdrop: 1040;


### PR DESCRIPTION
This PR increases the default `z-index` for Dropdown popover, so that it doesn't get hidden by the fixed header in some shells

Closes #955