### PR TITLE
fix: 🐛 fix context menu position in relative parent

### DIFF
--- a/libs/angular/src/lib/context-menu/context-menu.component.html
+++ b/libs/angular/src/lib/context-menu/context-menu.component.html
@@ -10,27 +10,29 @@
   </ng-container>
 </button>
 
-<div
-  class="popover popover-context-menu"
-  [class.active]="isActive"
-  [style.top]="top"
-  [style.left]="left"
-  #contextMenuPopover
->
-  <ul role="listbox">
-    <li
-      *ngFor="let menuItem of menuItems"
-      (click)="onItemClick(menuItem)"
-      tabindex="0"
-      (keydown)="onMenuItemKeyDown($event, menuItem)"
-    >
-      <ng-container
-        [ngTemplateOutlet]="menuItemTemplate ?? defaultMenuItemTemplate"
-        [ngTemplateOutletContext]="{ $implicit: menuItem }"
+<div class="context-menu-overlay">
+  <div
+    class="popover popover-context-menu"
+    [class.active]="isActive"
+    [style.top]="top"
+    [style.left]="left"
+    #contextMenuPopover
+  >
+    <ul role="listbox">
+      <li
+        *ngFor="let menuItem of menuItems"
+        (click)="onItemClick(menuItem)"
+        tabindex="0"
+        (keydown)="onMenuItemKeyDown($event, menuItem)"
       >
-      </ng-container>
-    </li>
-  </ul>
+        <ng-container
+          [ngTemplateOutlet]="menuItemTemplate ?? defaultMenuItemTemplate"
+          [ngTemplateOutletContext]="{ $implicit: menuItem }"
+        >
+        </ng-container>
+      </li>
+    </ul>
+  </div>
 </div>
 
 <ng-template #defaultMenuItemTemplate let-menuItem>

--- a/libs/angular/src/lib/context-menu/context-menu.stories.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.stories.ts
@@ -124,3 +124,30 @@ DirectiveTemplateDefault.args = {
     { label: 'Option 3', value: 'option3' },
   ],
 }
+
+
+const TemplatePositionRelative: Story<NggContextMenuComponent> = (
+  args: NggContextMenuComponent
+) => ({
+  component: NggContextMenuComponent,
+  props: args,
+  template: `
+  <div style="position: relative; width: 50%; margin: 20px auto;">
+    <div style="display:flex;justify-content:space-between;">
+      <ngg-context-menu #ctx [direction]="direction" [menuItems]="menuItems"></ngg-context-menu>
+      <ngg-context-menu #ctx [direction]="direction" [menuItems]="menuItems"></ngg-context-menu>
+      <ngg-context-menu #ctx [direction]="direction" [menuItems]="menuItems"></ngg-context-menu>
+    </div>
+  </div>
+  `,
+})
+
+export const PositionRelative = TemplatePositionRelative.bind({})
+PositionRelative.args = {
+  direction: 'ltr',
+  menuItems: [
+    { label: 'Option 1', value: 'option1' },
+    { label: 'Option 2', value: 'option2' },
+    { label: 'Option 3', value: 'option3' },
+  ],
+}

--- a/libs/angular/src/lib/context-menu/documentation.mdx
+++ b/libs/angular/src/lib/context-menu/documentation.mdx
@@ -100,3 +100,10 @@ Example with directive for close on scroll used
 <Canvas>
   <Story id="components-context-menu--custom-template-default" />
 </Canvas>
+
+
+## Relative position
+
+<Canvas>
+  <Story id="components-context-menu--position-relative" />
+</Canvas>

--- a/libs/chlorophyll/scss/components/context-menu/_index.scss
+++ b/libs/chlorophyll/scss/components/context-menu/_index.scss
@@ -2,7 +2,13 @@
 @use '../../common';
 @use '../../components/popover';
 
+.context-menu-overlay {
+  @include mixins.add-context-menu-overlay();
+}
+
 .popover-context-menu {
+  pointer-events: auto;
+
   @include common.media-breakpoint-up('sm') {
     @include mixins.add-context-menu();
     border: none;

--- a/libs/chlorophyll/scss/components/context-menu/_mixins.scss
+++ b/libs/chlorophyll/scss/components/context-menu/_mixins.scss
@@ -5,6 +5,16 @@
 $box-shadow: 0rem 0rem 0.75rem 0rem rgba(0, 0, 0, 0.1);
 $font-weight: tokens.$font-weight-bold;
 
+@mixin add-context-menu-overlay {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  pointer-events: none;
+}
+
 @mixin add-context-menu {
   @include common.add-border-radius();
   @include common.add-focus('');


### PR DESCRIPTION
When context menu was put in a parent HTML element, it was displayed in a wrong position due to top and left coordinates being calculated from the whole window, not from parent coordinate system. This change introduces an overlay in order to mitigate the issue in the simplest possible manner. The solution was inspired by material angular library tooltip component implementation.

BREAKING CHANGE: 🧨 -

✅ Closes: -