### PR TITLE
fix: 🐛 wrong calculation of y position for context menu

### DIFF
--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -94,12 +94,12 @@ export class NggContextMenuComponent
     const anchor = this.anchor?.nativeElement as HTMLElement
     const buttonRect = anchor.getBoundingClientRect()
 
-    const left = this.calculateLeft(this.direction, buttonRect)
-    const top = this.calculateTop(buttonRect.bottom)
     const gapBetweenButtonAndPopover = 3
+    const left = this.calculateLeft(this.direction, buttonRect)
+    const top = buttonRect.bottom + gapBetweenButtonAndPopover;
 
     this.left = `${left}px`
-    this.top = `${top + gapBetweenButtonAndPopover}px`
+    this.top = `${top}px`
     this.isActive = true
   }
 
@@ -123,10 +123,6 @@ export class NggContextMenuComponent
       default:
         break
     }
-  }
-
-  calculateTop(buttonRectBottom: number): number {
-    return buttonRectBottom + window.pageYOffset
   }
 
   calculateLeft(direction: string, buttonRect: DOMRect): number {


### PR DESCRIPTION
Due to the previous fix for x and y positions (adding an overlay) it is no longer needed to add scroll offset to the context menu y position.

BREAKING CHANGE: 🧨 -

✅ Closes: -