### PR TITLE
fix(typography): switch back to unitless `line-height` for body

### DIFF
--- a/libs/chlorophyll/scss/components/reset/mixins.scss
+++ b/libs/chlorophyll/scss/components/reset/mixins.scss
@@ -48,7 +48,7 @@ with minor modifications as well as splitting in to mixins */
 /* Set core body defaults */
 @mixin _body-default($selector: body) {
   #{$selector} {
-    line-height: 1.125rem;
+    line-height: 1.125;
     @if ($selector == body) {
       min-height: 100vh;
     }

--- a/libs/chlorophyll/scss/components/reset/reset.scss
+++ b/libs/chlorophyll/scss/components/reset/reset.scss
@@ -38,9 +38,11 @@ html:focus-within {
 
 /* Set core body defaults */
 body {
-  line-height: 1.125rem;
+  line-height: 1.125;
   min-height: 100vh;
   text-rendering: optimizeSpeed;
+  font-family: tokens.font-family('sans');
+  font-size: tokens.$base-font-size;
 }
 
 /* A elements that don't have a class get default styles */
@@ -79,9 +81,4 @@ select {
     scroll-behavior: auto !important;
     transition-duration: 0.01ms !important;
   }
-}
-
-body {
-  font-family: tokens.font-family('sans');
-  font-size: tokens.$base-font-size;
 }


### PR DESCRIPTION
The current fixed rem based unit cause issues in situations where font-size is enlarged.