### PR TITLE
fix(react): fixed radio group prop type expandableInfo

### DIFF
--- a/libs/extract/src/lib/form.ts
+++ b/libs/extract/src/lib/form.ts
@@ -1,1 +1,8 @@
+import { ReactNode } from 'react'
+
 export type FormDirection = 'horizontal' | 'vertical'
+
+export interface IExpandableInformation {
+  expandableInfo?: ReactNode
+  expandableInfoButtonLabel?: string
+}

--- a/libs/react/src/lib/form/radioButton/radioGroup.stories.mdx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.stories.mdx
@@ -106,7 +106,7 @@ Together, `RadioGroup` and `RadioButton` components facilitate the use of radio 
 | labelInformation?          | `string`                                           | Additional information for the label                                                                          |
 | valueSelected?             | `string`                                           | The currently selected value in the radio group. Needs to match the string value of an enclosed `RadioButton` |
 | description?               | `string`                                           | Description for the radio group                                                                               |
-| expandableInfo?            | `string`                                           | Expandable information text                                                                                   |
+| expandableInfo?            | `ReactNode`                                           | Expandable information text                                                                                   |
 | expandableInfoButtonLabel? | `string`                                           | Label for the expandable info button                                                                          |
 | defaultSelected?           | `string`                                           | Default selected value in the radio group                                                                     |
 | validator?                 | `IValidator`                                       | Validator function for radio group values                                                                     |

--- a/libs/react/src/lib/form/radioButton/radioGroup.tsx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.tsx
@@ -5,18 +5,17 @@ import {
   IndicatorType,
   validateClassName,
   randomId,
+  IExpandableInformation,
 } from '@sebgroup/extract'
 import { FormItem } from '../../formItem'
 import classNames from 'classnames'
 
-export interface RadioGroupProps {
+export interface RadioGroupProps extends IExpandableInformation {
   label?: string
   title?: string
   labelInformation?: string
   valueSelected?: string
   description?: string
-  expandableInfo?: string
-  expandableInfoButtonLabel?: string
   defaultSelected?: string
   validator?: IValidator
   onChangeRadio?: (value: string) => string

--- a/libs/react/src/lib/form/types.ts
+++ b/libs/react/src/lib/form/types.ts
@@ -1,13 +1,13 @@
-import { IValidator } from '@sebgroup/extract'
+import { IValidator, IExpandableInformation } from '@sebgroup/extract'
 import React, { HTMLProps } from 'react'
 
-export interface TextInputProps extends HTMLProps<HTMLInputElement> {
+export interface TextInputProps
+  extends HTMLProps<HTMLInputElement>,
+    IExpandableInformation {
   type?: 'text' | 'email' | 'number'
   label?: string
   info?: string
   testId?: string
-  expandableInfo?: React.ReactNode
-  expandableInfoButtonLabel?: string
   validator?: IValidator
   onChangeInput?: (value: string) => string
 }
@@ -17,8 +17,6 @@ export interface NumberInputProps extends TextInputProps {
   min?: number
   max?: number
   step?: number
-  expandableInfo?: React.ReactNode
-  expandableInfoButtonLabel?: string
 }
 
 export interface CheckboxProps extends HTMLProps<HTMLInputElement> {

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -2,6 +2,7 @@ import IconButton from '../form/iconButton/iconButton'
 import {
   debounce,
   delay,
+  IExpandableInformation,
   IValidator,
   randomId,
   validateClassName,
@@ -16,16 +17,14 @@ import React, {
 import { InfoCircle, Times } from '../icons'
 import classNames from 'classnames'
 
-interface FormItemProps {
+interface FormItemProps extends IExpandableInformation {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onChangeInput?: (value: string) => string
   label?: string
   labelInformation?: string
   validator?: IValidator
-  expandableInfo?: React.ReactNode
   inputId?: string
   children: ReactNode
-  expandableInfoButtonLabel?: string
   role?: string
 }
 


### PR DESCRIPTION
Extracting properties to its own interface to ensure consistency of this functionality. RadioGroup and Inputs had different interfaces for expandable info props. They should now extend the IExpandableInformation.