### PR TITLE
fix: 🐛 wrong position after zoom-in due to cached position

### DIFF
--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -17,6 +17,7 @@ import {
 import { DropdownOption } from '@sebgroup/extract'
 import { Subject, Subscription } from 'rxjs'
 import { ON_SCROLL_TOKEN } from '../shared/on-scroll.directive'
+import { CONTEXT_MENU_LEFT, CONTEXT_MENU_TOP } from './context-menu.constants'
 
 @Component({
   selector: 'ngg-context-menu',
@@ -34,20 +35,20 @@ export class NggContextMenuComponent
   @Output() contextMenuItemClicked: EventEmitter<DropdownOption> =
     new EventEmitter<DropdownOption>()
 
-  @ViewChild('contextMenuPopover') popover: ElementRef | undefined
+  @ViewChild('contextMenuPopover') popover!: ElementRef<HTMLElement>
 
-  @ViewChild('contextMenuAnchor') anchor: ElementRef | undefined
+  @ViewChild('contextMenuAnchor') anchor!: ElementRef<HTMLElement>
 
   isActive = false
-  top = '0px'
-  left = '0px'
+  top = CONTEXT_MENU_TOP
+  left = CONTEXT_MENU_LEFT
 
   resizeObserver?: ResizeObserver
   menuCloseSubscription?: Subscription
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
-    private elementRef: ElementRef,
+    private elementRef: ElementRef<HTMLElement>,
     @Optional()
     @Inject(ON_SCROLL_TOKEN)
     public closeContextMenu: Subject<void>
@@ -58,9 +59,8 @@ export class NggContextMenuComponent
     if (!this.isActive) {
       return
     }
-    const contextMenuElement = this.elementRef.nativeElement as HTMLElement
 
-    if (!contextMenuElement.contains(target)) {
+    if (!this.elementRef.nativeElement.contains(target)) {
       this.close()
     }
   }
@@ -91,8 +91,7 @@ export class NggContextMenuComponent
       return
     }
 
-    const anchor = this.anchor?.nativeElement as HTMLElement
-    const buttonRect = anchor.getBoundingClientRect()
+    const buttonRect = this.anchor?.nativeElement.getBoundingClientRect()
 
     const left = this.calculateLeft(this.direction, buttonRect)
     const top = this.calculateTop(buttonRect.bottom)
@@ -105,6 +104,8 @@ export class NggContextMenuComponent
 
   close(): void {
     this.isActive = false
+    this.top = CONTEXT_MENU_TOP
+    this.left = CONTEXT_MENU_LEFT
     this.changeDetectorRef.markForCheck()
   }
 

--- a/libs/angular/src/lib/context-menu/context-menu.constants.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.constants.ts
@@ -1,0 +1,3 @@
+export const CONTEXT_MENU_TOP = '0px';
+
+export const CONTEXT_MENU_LEFT = '0px';


### PR DESCRIPTION
When zooming in / out the component does not reset it's position to (0; 0), hence when no width (only max-width) is specified the initial boundary condition on how to display it when it is close to the border of the container does not fully suffice and produce incorrect dynamic width (open and close differs in the context menu width too)

BREAKING CHANGE: 🧨 -

✅ Closes: -