### PR TITLE
fix: Angular modal scroll iOS

### DIFF
--- a/libs/angular/src/lib/modal/documentation.mdx
+++ b/libs/angular/src/lib/modal/documentation.mdx
@@ -1,7 +1,7 @@
 import { NggModalComponent } from './modal.component'
 import { Canvas, Story } from '@storybook/addon-docs'
 
-# Modal 
+# Modal
 
 ## Importing module
 
@@ -32,8 +32,8 @@ Green currently provides three different variants of the modal - **dialog** (def
 |:--------|:----------|:------|
 |modalType|`ModalType`|The type of modal. Can be: `default` (dialog), `slideout` (slide-out), `takeover` (fullscreen).|
 |header|`string`|The header text of the modal.|
-|confirm|`string`|The text of the confirm button.|
-|dismiss|`string`|The text of the dismiss button.|
+|confirmLabel|`string`|The text of the confirm button.|
+|dismissLabel|`string`|The text of the dismiss button.|
 |size|`string`|The size of the modal.|
 |isOpen|`boolean`|Determines whether the modal is open of closed.|
 |trapFocus|`boolean`|Determines whether focus should be trapped inside the modal or not.|
@@ -43,9 +43,9 @@ Green currently provides three different variants of the modal - **dialog** (def
 |Event|Description|
 |:--------|:------|
 |isOpenChange|Event emitted when modal is opened or closed. Note that the event is not emitted if subscribed to `onClose`.|
-|onClose|Event emitted when modal is usually closed (but modal is not closed and will not close by itself). When subscribed to this event you will need to close the modal manually e.g. by updating the `isOpen` property.|
-|onConfirm|Event emitted when confirm button is clicked.|
-|onDismiss|Event emitted when dismiss button is clicked.|
+|closed|Event emitted when modal is usually closed (but modal is not closed and will not close by itself). When subscribed to this event you will need to close the modal manually e.g. by updating the `isOpen` property.|
+|confirm|Event emitted when confirm button is clicked.|
+|dismiss|Event emitted when dismiss button is clicked.|
 
 ## Examples
 

--- a/libs/angular/src/lib/modal/modal.component.ts
+++ b/libs/angular/src/lib/modal/modal.component.ts
@@ -2,129 +2,134 @@ import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBindi
 import { ModalType, Size } from '@sebgroup/extract';
 import { ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import {
-    disableBodyScroll,
-    enableBodyScroll,
+  disableBodyScroll,
+  enableBodyScroll,
 } from "body-scroll-lock";
 
 @Component({
-    selector: 'ngg-modal',
-    styleUrls: ['./modal.component.scss'],
-    templateUrl: './modal.component.html',
-    changeDetection: ChangeDetectionStrategy.OnPush
+  selector: 'ngg-modal',
+  styleUrls: ['./modal.component.scss'],
+  templateUrl: './modal.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NggModalComponent implements OnDestroy, OnInit {
-    @Input() public modalType?: ModalType
-    @Input() public header?: string
-    @Input() public confirmLabel?: string
-    @Input() public dismissLabel?: string
-    @Input() public size?: Size
-    @Input() public get trapFocus(): boolean | undefined {
-        return this._trapFocus;
+  @Input() public modalType?: ModalType
+  @Input() public header?: string
+  @Input() public confirmLabel?: string
+  @Input() public dismissLabel?: string
+  @Input() public size?: Size
+  @Input() public get trapFocus(): boolean | undefined {
+    return this._trapFocus;
+  }
+  public set trapFocus(value: boolean | undefined) {
+    this._trapFocus = value;
+
+    if (value) {
+      if (this._isOpen) {
+        this.enableFocusTrap();
+      }
+    } else {
+      this.disableFocusTrap();
     }
-    public set trapFocus(value: boolean | undefined) {
-        this._trapFocus = value;
-        
-        if (value) {
-            if (this._isOpen) {
-                this.enableFocusTrap();
-            }
-        } else {
-            this.disableFocusTrap();
+  }
+
+  @Input()
+  public get isOpen(): boolean | undefined {
+    return this._isOpen;
+  }
+  public set isOpen(value: boolean | undefined) {
+    this._isOpen = value;
+
+    if (value) {
+      if (this.trapFocus) {
+        this.enableFocusTrap();
+      }
+
+      disableBodyScroll(this.ref.nativeElement, {
+        allowTouchMove: (el) => {
+          // Allow touchmove for elements inside modal, its required for scroll to work on iOS devices
+          return this.ref.nativeElement.contains(el);
         }
+      });
+    } else {
+      this.disableFocusTrap();
+      enableBodyScroll(this.ref.nativeElement);
     }
+  }
 
-    @Input()
-    public get isOpen(): boolean | undefined {
-        return this._isOpen;
+  @Output() public isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() public closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+  @Output() public confirm: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+  @Output() public dismiss: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+
+  @HostBinding('class.open') get open() { return this.isOpen; }
+  @ViewChild('backdrop') private backdropRef?: ElementRef<HTMLInputElement>;
+  private _isOpen?: boolean;
+  private _trapFocus?: boolean;
+  private configurableFocusTrap: ConfigurableFocusTrap;
+
+  constructor(private ref: ElementRef<HTMLElement>, private configurableFocusTrapFactory: ConfigurableFocusTrapFactory) {
+    this.configurableFocusTrap = this.configurableFocusTrapFactory.create(this.ref.nativeElement);
+  }
+
+  ngOnInit(): void {
+    if (this._isOpen && this.trapFocus)
+      this.enableFocusTrap();
+    else
+      this.disableFocusTrap();
+  }
+
+  public handleCloseClick(event: MouseEvent) {
+    this.closeModal(event);
+  }
+
+  public handleBackdropClick(event: MouseEvent) {
+    if (event.target == this.backdropRef?.nativeElement)
+      this.closeModal(event);
+  }
+
+  public handleDismiss(event: MouseEvent) {
+    this.dismiss.emit(event);
+  }
+
+  public handleConfirm(event: MouseEvent) {
+    this.confirm.emit(event);
+  }
+
+  private closeModal(event: MouseEvent) {
+    if (this.closed.observers.length > 0) {
+      this.closed.emit(event);
     }
-    public set isOpen(value: boolean | undefined) {
-        this._isOpen = value;
-
-        if (value) {
-            if (this.trapFocus) {
-                this.enableFocusTrap();
-            }
-
-            disableBodyScroll(this.ref.nativeElement);
-        } else {
-            this.disableFocusTrap();
-            enableBodyScroll(this.ref.nativeElement);
-        }
+    else {
+      this.isOpen = false;
+      this.isOpenChange.emit(this.isOpen);
     }
+  }
 
-    @Output() public isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
-    @Output() public closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-    @Output() public confirm: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-    @Output() public dismiss: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-
-    @HostBinding('class.open') get open() { return this.isOpen; }
-    @ViewChild('backdrop') private backdropRef?: ElementRef<HTMLInputElement>;
-    private _isOpen?: boolean;
-    private _trapFocus?: boolean;
-    private configurableFocusTrap: ConfigurableFocusTrap;
-
-    constructor(private ref: ElementRef<HTMLElement>, private configurableFocusTrapFactory: ConfigurableFocusTrapFactory) {
-        this.configurableFocusTrap = this.configurableFocusTrapFactory.create(this.ref.nativeElement);
+  private enableFocusTrap() {
+    if (this.configurableFocusTrap) {
+      this.configurableFocusTrap.enabled = true;
+      this.configurableFocusTrap.focusInitialElementWhenReady();
     }
+  }
 
-    ngOnInit(): void {
-        if (this._isOpen && this.trapFocus) 
-           this.enableFocusTrap(); 
-        else
-            this.disableFocusTrap();
+  private disableFocusTrap() {
+    if (this.configurableFocusTrap) {
+      this.configurableFocusTrap.enabled = false;
     }
+  }
 
-    public handleCloseClick(event: MouseEvent) {
-        this.closeModal(event);
-    }
-
-    public handleBackdropClick(event: MouseEvent) {
-        if (event.target == this.backdropRef?.nativeElement)
-            this.closeModal(event);
-    }
-
-    public handleDismiss(event: MouseEvent) {
-        this.dismiss.emit(event);
-    }
-
-    public handleConfirm(event: MouseEvent) {
-        this.confirm.emit(event);
-    }
-
-    private closeModal(event: MouseEvent) {
-        if (this.closed.observers.length > 0) {
-            this.closed.emit(event);
-        }
-        else {
-            this.isOpen = false;
-            this.isOpenChange.emit(this.isOpen);
-        }
-    }
-
-    private enableFocusTrap() {
-        if (this.configurableFocusTrap) {
-            this.configurableFocusTrap.enabled = true;
-            this.configurableFocusTrap.focusInitialElementWhenReady();
-        }
-    }
-    
-    private disableFocusTrap() {
-        if (this.configurableFocusTrap) {
-            this.configurableFocusTrap.enabled = false;
-        }
-    }
-
-    ngOnDestroy(): void {
-        this.configurableFocusTrap?.destroy();
-        enableBodyScroll(this.ref.nativeElement);
-    }
+  ngOnDestroy(): void {
+    this.configurableFocusTrap?.destroy();
+    enableBodyScroll(this.ref.nativeElement);
+  }
 }
 
 @Component({
-    // eslint-disable-next-line @angular-eslint/component-selector
-    selector: '[ngg-modal-header]',
-    styleUrls: ['./modal.component.scss'],
-    template: `
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '[ngg-modal-header]',
+  styleUrls: ['./modal.component.scss'],
+  template: `
     <h3 data-testid="modal-header-text">{{header}}</h3>
     <button data-testid="modal-close-button" class="close" (click)="this.handleClose($event)">
         <span className="sr-only">Close</span>
@@ -133,44 +138,44 @@ export class NggModalComponent implements OnDestroy, OnInit {
     `
 })
 export class NggModalHeaderComponent {
-    @Input() header?: string;
-    @Output() closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+  @Input() header?: string;
+  @Output() closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-    handleClose(event: MouseEvent) {
-        this.closed.emit(event);
-    }
+  handleClose(event: MouseEvent) {
+    this.closed.emit(event);
+  }
 
 }
 
 @Component({
-    // eslint-disable-next-line @angular-eslint/component-selector
-    selector: '[ngg-modal-body]',
-    styleUrls: ['./modal.component.scss'],
-    template: `<ng-content></ng-content>`
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '[ngg-modal-body]',
+  styleUrls: ['./modal.component.scss'],
+  template: `<ng-content></ng-content>`
 })
 export class NggModalBodyComponent {
 }
 
 @Component({
-    // eslint-disable-next-line @angular-eslint/component-selector
-    selector: '[ngg-modal-footer]',
-    styleUrls: ['./modal.component.scss'],
-    template: `
+  // eslint-disable-next-line @angular-eslint/component-selector
+  selector: '[ngg-modal-footer]',
+  styleUrls: ['./modal.component.scss'],
+  template: `
     <button data-testid="modal-dismiss-button" *ngIf="dismissLabel" class="secondary" (click)="this.handleDismiss($event)">{{dismissLabel}}</button>
     <button data-testid="modal-confirm-button" *ngIf="confirmLabel" class="primary" (click)="this.handleConfirm($event)">{{confirmLabel}}</button>
     `
 })
 export class NggModalFooterComponent {
-    @Input() dismissLabel?: string;
-    @Input() confirmLabel?: string;
-    @Output() dismiss: EventEmitter<MouseEvent> = new EventEmitter();
-    @Output() confirm: EventEmitter<MouseEvent> = new EventEmitter();
+  @Input() dismissLabel?: string;
+  @Input() confirmLabel?: string;
+  @Output() dismiss: EventEmitter<MouseEvent> = new EventEmitter();
+  @Output() confirm: EventEmitter<MouseEvent> = new EventEmitter();
 
-    handleDismiss(event: MouseEvent) {
-        this.dismiss.emit(event);
-    }
+  handleDismiss(event: MouseEvent) {
+    this.dismiss.emit(event);
+  }
 
-    handleConfirm(event: MouseEvent) {
-        this.confirm.emit(event);
-    }
+  handleConfirm(event: MouseEvent) {
+    this.confirm.emit(event);
+  }
 }

--- a/libs/angular/src/lib/modal/modal.component.ts
+++ b/libs/angular/src/lib/modal/modal.component.ts
@@ -2,134 +2,134 @@ import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, HostBindi
 import { ModalType, Size } from '@sebgroup/extract';
 import { ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import {
-  disableBodyScroll,
-  enableBodyScroll,
+    disableBodyScroll,
+    enableBodyScroll,
 } from "body-scroll-lock";
 
 @Component({
-  selector: 'ngg-modal',
-  styleUrls: ['./modal.component.scss'],
-  templateUrl: './modal.component.html',
-  changeDetection: ChangeDetectionStrategy.OnPush
+    selector: 'ngg-modal',
+    styleUrls: ['./modal.component.scss'],
+    templateUrl: './modal.component.html',
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class NggModalComponent implements OnDestroy, OnInit {
-  @Input() public modalType?: ModalType
-  @Input() public header?: string
-  @Input() public confirmLabel?: string
-  @Input() public dismissLabel?: string
-  @Input() public size?: Size
-  @Input() public get trapFocus(): boolean | undefined {
-    return this._trapFocus;
-  }
-  public set trapFocus(value: boolean | undefined) {
-    this._trapFocus = value;
-
-    if (value) {
-      if (this._isOpen) {
-        this.enableFocusTrap();
-      }
-    } else {
-      this.disableFocusTrap();
+    @Input() public modalType?: ModalType
+    @Input() public header?: string
+    @Input() public confirmLabel?: string
+    @Input() public dismissLabel?: string
+    @Input() public size?: Size
+    @Input() public get trapFocus(): boolean | undefined {
+        return this._trapFocus;
     }
-  }
+    public set trapFocus(value: boolean | undefined) {
+        this._trapFocus = value;
 
-  @Input()
-  public get isOpen(): boolean | undefined {
-    return this._isOpen;
-  }
-  public set isOpen(value: boolean | undefined) {
-    this._isOpen = value;
-
-    if (value) {
-      if (this.trapFocus) {
-        this.enableFocusTrap();
-      }
-
-      disableBodyScroll(this.ref.nativeElement, {
-        allowTouchMove: (el) => {
-          // Allow touchmove for elements inside modal, its required for scroll to work on iOS devices
-          return this.ref.nativeElement.contains(el);
+        if (value) {
+            if (this._isOpen) {
+                this.enableFocusTrap();
+            }
+        } else {
+            this.disableFocusTrap();
         }
-      });
-    } else {
-      this.disableFocusTrap();
-      enableBodyScroll(this.ref.nativeElement);
     }
-  }
 
-  @Output() public isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
-  @Output() public closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-  @Output() public confirm: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-  @Output() public dismiss: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
-
-  @HostBinding('class.open') get open() { return this.isOpen; }
-  @ViewChild('backdrop') private backdropRef?: ElementRef<HTMLInputElement>;
-  private _isOpen?: boolean;
-  private _trapFocus?: boolean;
-  private configurableFocusTrap: ConfigurableFocusTrap;
-
-  constructor(private ref: ElementRef<HTMLElement>, private configurableFocusTrapFactory: ConfigurableFocusTrapFactory) {
-    this.configurableFocusTrap = this.configurableFocusTrapFactory.create(this.ref.nativeElement);
-  }
-
-  ngOnInit(): void {
-    if (this._isOpen && this.trapFocus)
-      this.enableFocusTrap();
-    else
-      this.disableFocusTrap();
-  }
-
-  public handleCloseClick(event: MouseEvent) {
-    this.closeModal(event);
-  }
-
-  public handleBackdropClick(event: MouseEvent) {
-    if (event.target == this.backdropRef?.nativeElement)
-      this.closeModal(event);
-  }
-
-  public handleDismiss(event: MouseEvent) {
-    this.dismiss.emit(event);
-  }
-
-  public handleConfirm(event: MouseEvent) {
-    this.confirm.emit(event);
-  }
-
-  private closeModal(event: MouseEvent) {
-    if (this.closed.observers.length > 0) {
-      this.closed.emit(event);
+    @Input()
+    public get isOpen(): boolean | undefined {
+        return this._isOpen;
     }
-    else {
-      this.isOpen = false;
-      this.isOpenChange.emit(this.isOpen);
-    }
-  }
+    public set isOpen(value: boolean | undefined) {
+        this._isOpen = value;
 
-  private enableFocusTrap() {
-    if (this.configurableFocusTrap) {
-      this.configurableFocusTrap.enabled = true;
-      this.configurableFocusTrap.focusInitialElementWhenReady();
-    }
-  }
+        if (value) {
+            if (this.trapFocus) {
+                this.enableFocusTrap();
+            }
 
-  private disableFocusTrap() {
-    if (this.configurableFocusTrap) {
-      this.configurableFocusTrap.enabled = false;
+            disableBodyScroll(this.ref.nativeElement, {
+                allowTouchMove: (el) => {
+                    // Allow touchmove for elements inside modal, its required for scroll to work on iOS devices
+                    return this.ref.nativeElement.contains(el);
+                }
+            });
+        } else {
+            this.disableFocusTrap();
+            enableBodyScroll(this.ref.nativeElement);
+        }
     }
-  }
 
-  ngOnDestroy(): void {
-    this.configurableFocusTrap?.destroy();
-    enableBodyScroll(this.ref.nativeElement);
-  }
+    @Output() public isOpenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+    @Output() public closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+    @Output() public confirm: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+    @Output() public dismiss: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+
+    @HostBinding('class.open') get open() { return this.isOpen; }
+    @ViewChild('backdrop') private backdropRef?: ElementRef<HTMLInputElement>;
+    private _isOpen?: boolean;
+    private _trapFocus?: boolean;
+    private configurableFocusTrap: ConfigurableFocusTrap;
+
+    constructor(private ref: ElementRef<HTMLElement>, private configurableFocusTrapFactory: ConfigurableFocusTrapFactory) {
+        this.configurableFocusTrap = this.configurableFocusTrapFactory.create(this.ref.nativeElement);
+    }
+
+    ngOnInit(): void {
+        if (this._isOpen && this.trapFocus)
+            this.enableFocusTrap();
+        else
+            this.disableFocusTrap();
+    }
+
+    public handleCloseClick(event: MouseEvent) {
+        this.closeModal(event);
+    }
+
+    public handleBackdropClick(event: MouseEvent) {
+        if (event.target == this.backdropRef?.nativeElement)
+            this.closeModal(event);
+    }
+
+    public handleDismiss(event: MouseEvent) {
+        this.dismiss.emit(event);
+    }
+
+    public handleConfirm(event: MouseEvent) {
+        this.confirm.emit(event);
+    }
+
+    private closeModal(event: MouseEvent) {
+        if (this.closed.observers.length > 0) {
+            this.closed.emit(event);
+        }
+        else {
+            this.isOpen = false;
+            this.isOpenChange.emit(this.isOpen);
+        }
+    }
+
+    private enableFocusTrap() {
+        if (this.configurableFocusTrap) {
+            this.configurableFocusTrap.enabled = true;
+            this.configurableFocusTrap.focusInitialElementWhenReady();
+        }
+    }
+
+    private disableFocusTrap() {
+        if (this.configurableFocusTrap) {
+            this.configurableFocusTrap.enabled = false;
+        }
+    }
+
+    ngOnDestroy(): void {
+        this.configurableFocusTrap?.destroy();
+        enableBodyScroll(this.ref.nativeElement);
+    }
 }
 
 @Component({
-  // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '[ngg-modal-header]',
-  styleUrls: ['./modal.component.scss'],
-  template: `
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[ngg-modal-header]',
+    styleUrls: ['./modal.component.scss'],
+    template: `
     <h3 data-testid="modal-header-text">{{header}}</h3>
     <button data-testid="modal-close-button" class="close" (click)="this.handleClose($event)">
         <span className="sr-only">Close</span>
@@ -138,44 +138,44 @@ export class NggModalComponent implements OnDestroy, OnInit {
     `
 })
 export class NggModalHeaderComponent {
-  @Input() header?: string;
-  @Output() closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+    @Input() header?: string;
+    @Output() closed: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
-  handleClose(event: MouseEvent) {
-    this.closed.emit(event);
-  }
+    handleClose(event: MouseEvent) {
+        this.closed.emit(event);
+    }
 
 }
 
 @Component({
-  // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '[ngg-modal-body]',
-  styleUrls: ['./modal.component.scss'],
-  template: `<ng-content></ng-content>`
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[ngg-modal-body]',
+    styleUrls: ['./modal.component.scss'],
+    template: `<ng-content></ng-content>`
 })
 export class NggModalBodyComponent {
 }
 
 @Component({
-  // eslint-disable-next-line @angular-eslint/component-selector
-  selector: '[ngg-modal-footer]',
-  styleUrls: ['./modal.component.scss'],
-  template: `
+    // eslint-disable-next-line @angular-eslint/component-selector
+    selector: '[ngg-modal-footer]',
+    styleUrls: ['./modal.component.scss'],
+    template: `
     <button data-testid="modal-dismiss-button" *ngIf="dismissLabel" class="secondary" (click)="this.handleDismiss($event)">{{dismissLabel}}</button>
     <button data-testid="modal-confirm-button" *ngIf="confirmLabel" class="primary" (click)="this.handleConfirm($event)">{{confirmLabel}}</button>
     `
 })
 export class NggModalFooterComponent {
-  @Input() dismissLabel?: string;
-  @Input() confirmLabel?: string;
-  @Output() dismiss: EventEmitter<MouseEvent> = new EventEmitter();
-  @Output() confirm: EventEmitter<MouseEvent> = new EventEmitter();
+    @Input() dismissLabel?: string;
+    @Input() confirmLabel?: string;
+    @Output() dismiss: EventEmitter<MouseEvent> = new EventEmitter();
+    @Output() confirm: EventEmitter<MouseEvent> = new EventEmitter();
 
-  handleDismiss(event: MouseEvent) {
-    this.dismiss.emit(event);
-  }
+    handleDismiss(event: MouseEvent) {
+        this.dismiss.emit(event);
+    }
 
-  handleConfirm(event: MouseEvent) {
-    this.confirm.emit(event);
-  }
+    handleConfirm(event: MouseEvent) {
+        this.confirm.emit(event);
+    }
 }

--- a/libs/angular/src/lib/modal/modal.stories.ts
+++ b/libs/angular/src/lib/modal/modal.stories.ts
@@ -24,8 +24,8 @@ const Template: Story<NggModalComponent> = (args: NggModalComponent) => {
 
   return {
   template: `
-    <ngg-modal [modalType]="modalType" [header]="header" [isOpen]="isOpen" [confirmLabel]="confirmLabel" [dismissLabel]="dismissLabel" [trapFocus]="true" (closed)="isOpen = false">
-        <p>Modal Body</p>
+    <ngg-modal [modalType]="modalType" [header]="header" [isOpen]="isOpen" [confirmLabel]="confirmLabel" [dismissLabel]="dismissLabel" [trapFocus]="trapFocus" (closed)="isOpen = false">
+      <p>Modal Body</p>
     </ngg-modal>
     <button (click)="isOpen = true">Open Modal</button>
   `,
@@ -40,7 +40,8 @@ export const Default = Template.bind({})
 Default.args = {
     header: 'Header',
     dismissLabel: 'Secondary',
-    confirmLabel: 'Primary'
+    confirmLabel: 'Primary',
+    trapFocus: false
 }
 
 export const Slideout = Template.bind({})
@@ -48,7 +49,8 @@ Slideout.args = {
     modalType: 'slideout',
     header: 'Header',
     dismissLabel: 'Secondary',
-    confirmLabel: 'Primary'
+    confirmLabel: 'Primary',
+    trapFocus: false
 }
 
 export const Takeover = Template.bind({})
@@ -56,5 +58,6 @@ Takeover.args = {
     modalType: 'takeover',
     header: 'Header',
     dismissLabel: 'Secondary',
-    confirmLabel: 'Primary'
+    confirmLabel: 'Primary',
+    trapFocus: false
 }


### PR DESCRIPTION
Scrolling inside a modal (angular) on iOS devices didn't work. By allowing touchmove on elements inside the modal, solved the scrolling issue on iOS devices.

**Other**
- Typos in the modal (angular) documentation.
- Issue with having trapFocus enabled on all the modal (angular) examples in Firefox.