### PR TITLE
fix: 🐛 context menu used wrong change detection trigger

### DIFF
--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -106,7 +106,7 @@ export class NggContextMenuComponent
     this.isActive = false
     this.top = CONTEXT_MENU_TOP
     this.left = CONTEXT_MENU_LEFT
-    this.changeDetectorRef.markForCheck()
+    this.changeDetectorRef.detectChanges()
   }
 
   onItemClick(item: DropdownOption): void {


### PR DESCRIPTION
When using more complex events and extending the closing functionality of the context menu we noticed that sometimes angular doesn't catch the change detection trigger correctly. This was due to the fact that markchanges was used without PushStrategy.

BREAKING CHANGE: 🧨 -

✅ Closes: -