### PR TITLE
feat(react): information label can now be react node

### DIFF
--- a/apps/react-lib-dev/src/app/form.tsx
+++ b/apps/react-lib-dev/src/app/form.tsx
@@ -83,6 +83,11 @@ export const FormExample = () => {
         >
           <RadioGroup
             label="Radio Group"
+            labelInformation={
+              <>
+                This is a lable information with <a href="/to-a-page">a link</a>
+              </>
+            }
             onChange={(value) => console.log(value)}
           >
             <RadioButton label={'Fusilli'} value={'fusilli'} />

--- a/libs/chlorophyll/scss/components/form/common/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/common/_mixins.scss
@@ -154,6 +154,10 @@
 
     .form-info {
       margin-bottom: 0;
+
+      a:link:not(.button,[aria-disabled]) {
+        color: tokens.$link-color
+      }
     }
 
     > * {

--- a/libs/extract/src/lib/form.ts
+++ b/libs/extract/src/lib/form.ts
@@ -6,3 +6,8 @@ export interface IExpandableInformation {
   expandableInfo?: ReactNode
   expandableInfoButtonLabel?: string
 }
+
+export interface ILableAndLableInformation {
+  label?: string
+  labelInformation?: ReactNode
+}

--- a/libs/extract/src/lib/form.ts
+++ b/libs/extract/src/lib/form.ts
@@ -7,7 +7,7 @@ export interface IExpandableInformation {
   expandableInfoButtonLabel?: string
 }
 
-export interface ILableAndLableInformation {
+export interface ILabelAndLabelInformation {
   label?: string
   labelInformation?: ReactNode
 }

--- a/libs/react/src/lib/form/iconButton/iconButton.tsx
+++ b/libs/react/src/lib/form/iconButton/iconButton.tsx
@@ -8,7 +8,6 @@ interface IconButtonInterface {
   'aria-expanded'?: boolean
   'aria-controls'?: string
   size?: 'small' | 'normal'
-  name: string
 }
 
 const IconButton = ({ children, onClick, ...props }: IconButtonInterface) => {
@@ -19,7 +18,6 @@ const IconButton = ({ children, onClick, ...props }: IconButtonInterface) => {
       aria-controls={props['aria-controls']}
       aria-expanded={props['aria-expanded']}
       type={props.type ?? 'button'}
-      name={props.name}
     >
       {children}
     </button>

--- a/libs/react/src/lib/form/iconButton/iconButton.tsx
+++ b/libs/react/src/lib/form/iconButton/iconButton.tsx
@@ -8,6 +8,7 @@ interface IconButtonInterface {
   'aria-expanded'?: boolean
   'aria-controls'?: string
   size?: 'small' | 'normal'
+  name: string
 }
 
 const IconButton = ({ children, onClick, ...props }: IconButtonInterface) => {
@@ -18,6 +19,7 @@ const IconButton = ({ children, onClick, ...props }: IconButtonInterface) => {
       aria-controls={props['aria-controls']}
       aria-expanded={props['aria-expanded']}
       type={props.type ?? 'button'}
+      name={props.name}
     >
       {children}
     </button>

--- a/libs/react/src/lib/form/input/input.tsx
+++ b/libs/react/src/lib/form/input/input.tsx
@@ -16,7 +16,7 @@ export type Renderer = (
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void,
   onChangeInput?: (value: string) => string,
   label?: string,
-  info?: string,
+  info?: string | React.ReactNode,
   validator?: IValidator,
   expandableInfo?: React.ReactNode,
   expandableInfoButtonLabel?: string,

--- a/libs/react/src/lib/form/radioButton/radioGroup.tsx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.tsx
@@ -6,14 +6,14 @@ import {
   validateClassName,
   randomId,
   IExpandableInformation,
-  ILabelAndLableInformation,
+  ILabelAndLabelInformation,
 } from '@sebgroup/extract'
 import { FormItem } from '../../formItem'
 import classNames from 'classnames'
 
 export interface RadioGroupProps
   extends IExpandableInformation,
-    ILabelAndLableInformation {
+    ILabelAndLabelInformation {
   title?: string
   valueSelected?: string
   description?: string

--- a/libs/react/src/lib/form/radioButton/radioGroup.tsx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.tsx
@@ -102,13 +102,9 @@ export const RadioGroup = ({
 
   if (!name) name = randomId()
 
-  const radioGroupWrapperClassNames = classNames(
-    'gds-radio-group-wrapper',
-    {
-      'gds-radio-group-wrapper--horizontal': horizontal,
-    },
-    validatorClassName
-  )
+  const radioGroupWrapperClassNames = classNames('gds-radio-group-wrapper', {
+    'gds-radio-group-wrapper--horizontal': horizontal,
+  })
 
   return (
     <FormItem {...formItemProps}>

--- a/libs/react/src/lib/form/radioButton/radioGroup.tsx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.tsx
@@ -6,14 +6,14 @@ import {
   validateClassName,
   randomId,
   IExpandableInformation,
-  ILableAndLableInformation,
+  ILabelAndLableInformation,
 } from '@sebgroup/extract'
 import { FormItem } from '../../formItem'
 import classNames from 'classnames'
 
 export interface RadioGroupProps
   extends IExpandableInformation,
-    ILableAndLableInformation {
+    ILabelAndLableInformation {
   title?: string
   valueSelected?: string
   description?: string

--- a/libs/react/src/lib/form/radioButton/radioGroup.tsx
+++ b/libs/react/src/lib/form/radioButton/radioGroup.tsx
@@ -6,14 +6,15 @@ import {
   validateClassName,
   randomId,
   IExpandableInformation,
+  ILableAndLableInformation,
 } from '@sebgroup/extract'
 import { FormItem } from '../../formItem'
 import classNames from 'classnames'
 
-export interface RadioGroupProps extends IExpandableInformation {
-  label?: string
+export interface RadioGroupProps
+  extends IExpandableInformation,
+    ILableAndLableInformation {
   title?: string
-  labelInformation?: string
   valueSelected?: string
   description?: string
   defaultSelected?: string
@@ -75,11 +76,11 @@ export const RadioGroup = ({
     if (radioBtnRef && radioBtnRef.current) {
       const form: HTMLFormElement = radioBtnRef?.current
         ?.form as HTMLFormElement
-      const resetListner = () => {
+      const resetListener = () => {
         setSelected(undefined)
       }
-      form?.addEventListener('reset', resetListner)
-      return () => form?.removeEventListener('reset', resetListner)
+      form?.addEventListener('reset', resetListener)
+      return () => form?.removeEventListener('reset', resetListener)
     } else {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       return () => {}
@@ -101,9 +102,13 @@ export const RadioGroup = ({
 
   if (!name) name = randomId()
 
-  const radioGroupWrapperClassNames = classNames('gds-radio-group-wrapper', {
-    'gds-radio-group-wrapper--horizontal': horizontal,
-  })
+  const radioGroupWrapperClassNames = classNames(
+    'gds-radio-group-wrapper',
+    {
+      'gds-radio-group-wrapper--horizontal': horizontal,
+    },
+    validatorClassName
+  )
 
   return (
     <FormItem {...formItemProps}>

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -3,6 +3,7 @@ import {
   debounce,
   delay,
   IExpandableInformation,
+  ILableAndLableInformation,
   IValidator,
   randomId,
   validateClassName,
@@ -17,11 +18,11 @@ import React, {
 import { InfoCircle, Times } from '../icons'
 import classNames from 'classnames'
 
-interface FormItemProps extends IExpandableInformation {
+interface FormItemProps
+  extends IExpandableInformation,
+    ILableAndLableInformation {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onChangeInput?: (value: string) => string
-  label?: string
-  labelInformation?: string
   validator?: IValidator
   inputId?: string
   children: ReactNode

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -3,7 +3,7 @@ import {
   debounce,
   delay,
   IExpandableInformation,
-  ILabelAndLableInformation,
+  ILabelAndLabelInformation,
   IValidator,
   randomId,
   validateClassName,
@@ -20,7 +20,7 @@ import classNames from 'classnames'
 
 interface FormItemProps
   extends IExpandableInformation,
-    ILabelAndLableInformation {
+    ILabelAndLabelInformation {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onChangeInput?: (value: string) => string
   validator?: IValidator

--- a/libs/react/src/lib/formItem/formItem.tsx
+++ b/libs/react/src/lib/formItem/formItem.tsx
@@ -3,7 +3,7 @@ import {
   debounce,
   delay,
   IExpandableInformation,
-  ILableAndLableInformation,
+  ILabelAndLableInformation,
   IValidator,
   randomId,
   validateClassName,
@@ -20,7 +20,7 @@ import classNames from 'classnames'
 
 interface FormItemProps
   extends IExpandableInformation,
-    ILableAndLableInformation {
+    ILabelAndLableInformation {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
   onChangeInput?: (value: string) => string
   validator?: IValidator


### PR DESCRIPTION
Adding the possibility to pass a react node to the information label. added some overriding temporary styling since it clashed with old generated styling based on key words.

Also extracted the label and label information types to it's own interface.

This was requested by the loan team.