### PR TITLE
fix(core): break out to separate build command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Install dependencies
         run: yarn install --prefer-offline --frozen-lockfile --silent
 
-      - name: Build all libraries
+      - name: Build core library
+        run: yarn build:core
+
+      - name: Build rest of libraries
         run: yarn build:libs
 
       - name: Version and release all libraries

--- a/libs/core/project.json
+++ b/libs/core/project.json
@@ -5,12 +5,6 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "nx run core:build-with-types-and-scoping"
-      }
-    },
-    "build-src": {
       "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
       "format": ["esm", "cjs"],
@@ -31,7 +25,7 @@
     },
     "build-with-types": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build-src"],
+      "dependsOn": ["build"],
       "options": {
         "command": "tsc --emitDeclarationOnly --declaration --project libs/core/tsconfig.lib.json"
       }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:all": "nx run-many --target=test --all",
     "lint": "nx workspace-lint && nx lint",
     "lint:all": "nx run-many --target=lint --all",
-    "smoketest": "yarn lint:all && yarn test:all && yarn build:all",
+    "smoketest": "yarn lint:all && yarn test:all && yarn build:core && yarn build:all",
     "affected:apps": "nx print-affected --type=app --select=projects",
     "affected:libs": "nx print-affected --type=lib --select=projects",
     "affected:build": "nx affected:build",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "nx": "nx",
-    "build:libs": "nx run-many -p core,angular,angular-charts,charts,chlorophyll,extract,react,react-charts  --target=build",
+    "build:core": "nx run core:build-with-types-and-scoping",
+    "build:libs": "nx run-many -p angular,angular-charts,charts,chlorophyll,extract,react,react-charts  --target=build",
     "build:apps": "nx run-many -p colors --target=build",
     "build:all": "yarn build:libs && yarn build:apps",
     "test": "nx test",


### PR DESCRIPTION
Suspecting that the publish target fails because I renamed the default build target to `build-src`. I think that causes the publish target to be unable to find the `outputPath` field. Let's see if this fixes it!