### PR TITLE
fix(core): attempt to fix build config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --prefer-offline --frozen-lockfile --silent
 
-      - name: Build rest of libraries
+      - name: Build libraries
         run: yarn build:libs
 
       - name: Version and release all libraries

--- a/libs/core/project.json
+++ b/libs/core/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "targets": {
     "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "nx run core:build-with-types-and-scoping"
+      }
+    },
+    "build-src": {
       "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],
       "format": ["esm", "cjs"],
@@ -31,7 +37,7 @@
     },
     "build-with-types": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["build-src"],
       "options": {
         "command": "tsc --emitDeclarationOnly --declaration --project libs/core/tsconfig.lib.json"
       }
@@ -107,11 +113,7 @@
         "push": true,
         "preid": "beta",
         "releaseAs": "prerelease",
-        "postTargets": [
-          "core:build-with-types-and-scoping",
-          "core:publish",
-          "core:github"
-        ]
+        "postTargets": ["core:publish", "core:github"]
       }
     },
     "github": {
@@ -125,7 +127,7 @@
       "executor": "ngx-deploy-npm:deploy",
       "options": {
         "access": "public",
-        "noBuild": true
+        "distFolderPath": "dist/libs/core/src"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "nx": "nx",
-    "build:core": "nx run core:build-with-types-and-scoping",
-    "build:libs": "nx run-many -p angular,angular-charts,charts,chlorophyll,extract,react,react-charts  --target=build",
+    "build:libs": "nx run-many -p core,angular,angular-charts,charts,chlorophyll,extract,react,react-charts  --target=build",
     "build:apps": "nx run-many -p colors --target=build",
-    "build:all": "yarn build:core && yarn build:libs && yarn build:apps",
+    "build:all": "yarn build:libs && yarn build:apps",
     "test": "nx test",
     "test:all": "nx run-many --target=test --all",
     "lint": "nx workspace-lint && nx lint",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:all": "nx run-many --target=test --all",
     "lint": "nx workspace-lint && nx lint",
     "lint:all": "nx run-many --target=lint --all",
-    "smoketest": "yarn lint:all && yarn test:all && yarn build:core && yarn build:all",
+    "smoketest": "yarn lint:all && yarn test:all && yarn build:all",
     "affected:apps": "nx print-affected --type=app --select=projects",
     "affected:libs": "nx print-affected --type=lib --select=projects",
     "affected:build": "nx affected:build",


### PR DESCRIPTION
Apparently running the build as a post-target of `version-and-release` did not work. For some reason the output folder is deleted before the next post target (publish) gets to run.

The main issue is that NX has no way of specifying an action that runs *after* a given target, and `ngx-deploy-npm` is hard-coded to use the `build` target. Green Core needs a few post-processing steps to run after the build, so we need to try and coerce `ngx-deploy-npm` to call another target than the actual `build` target.