### PR TITLE
fix: 🐛 edit button on mobile view

### DIFF
--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -2,6 +2,7 @@
 @use '../../../tokens';
 
 @mixin add-in-page-wizard {
+  $prefix: &;
   border: 0;
   margin-bottom: 0.5rem;
   padding: 0;
@@ -71,14 +72,6 @@
   &__header__title {
     grid-area: title;
   }
-  &__header__edit {
-    grid-area: edit;
-    display: none;
-    justify-content: end;
-    @media (min-width: 576px) {
-      display: flex;
-    }
-  }
 
   &__content {
     padding: 0.5rem 1rem 1.5rem 1rem;
@@ -91,7 +84,7 @@
   > footer {
     justify-content: flex-start;
   }
-  
+
   &__footer {
     border-top: 1px solid tokens.get(tokens.$grey, 500);
     padding: 1.5rem 1rem 1.5rem 1rem;
@@ -124,9 +117,29 @@
     background-color: tokens.get(tokens.$green, 1);
   }
 
-  &.completed &__footer {
-    @media (min-width: 576px) {
-      display: none;
+  &.completed {
+    &.editable {
+      #{$prefix}__header__edit {
+        grid-area: edit;
+        display: none;
+        justify-content: end;
+        @media (min-width: 576px) {
+          display: flex;
+        }
+      }
+
+      #{$prefix}__footer {
+        @media (min-width: 576px) {
+          display: none;
+        }
+      }
+    }
+
+    &:not(.editable) {
+      #{$prefix}__header__edit,
+      #{$prefix}__footer {
+        display: none;
+      }
     }
   }
 }

--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -84,7 +84,6 @@
   > footer {
     justify-content: flex-start;
   }
-
   &__footer {
     border-top: 1px solid tokens.get(tokens.$grey, 500);
     padding: 1.5rem 1rem 1.5rem 1rem;

--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -122,13 +122,13 @@
         grid-area: edit;
         display: none;
         justify-content: end;
-        @media (min-width: 576px) {
+        @include common.media-breakpoint-up('sm') {
           display: flex;
         }
       }
 
       #{$prefix}__footer {
-        @media (min-width: 576px) {
+        @include common.media-breakpoint-up('sm') {
           display: none;
         }
       }

--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -123,4 +123,10 @@
     display: flex;
     background-color: tokens.get(tokens.$green, 1);
   }
+
+  &.completed &__footer {
+    @media (min-width: 576px) {
+      display: none;
+    }
+  }
 }

--- a/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
+++ b/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
@@ -3,6 +3,7 @@ import { Meta, Story, Canvas } from '@storybook/addon-docs'
 export const Template = ({
   isCompleted,
   isStarted,
+  isEditable,
   stepText,
   title,
   content,
@@ -10,7 +11,11 @@ export const Template = ({
   return `
     <section class="gds-in-page-wizard-step-card card${
       isCompleted ? ' completed' : ''
-    }${isStarted ? ' active' : ''}">
+    }${
+      isStarted ? ' active' : ''
+    }${
+      isEditable ? ' editable' : ''
+    }">
       <header class="gds-in-page-wizard-step-card__header">
         <div class="gds-in-page-wizard-step-card__header__icon">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!-- Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) --><path d="M435.848 83.466L172.804 346.51l-96.652-96.652c-4.686-4.686-12.284-4.686-16.971 0l-28.284 28.284c-4.686 4.686-4.686 12.284 0 16.971l133.421 133.421c4.686 4.686 12.284 4.686 16.971 0l299.813-299.813c4.686-4.686 4.686-12.284 0-16.971l-28.284-28.284c-4.686-4.686-12.284-4.686-16.97 0z"/></svg>
@@ -34,7 +39,7 @@ export const Template = ({
         isStarted ? 
         `<div class="gds-in-page-wizard-step-card__content">${content}</div>
           <footer class="gds-in-page-wizard-step-card__footer">
-            ${isCompleted ? 
+            ${isCompleted ?
               `<button class="secondary">Edit</button>`
               :
               `<button class="primary">Next</button>`
@@ -59,6 +64,9 @@ export const Template = ({
     isStarted: {
       control: 'boolean',
     },
+    isEditable: {
+      control: 'boolean',
+    },
     stepText: { control: 'text' },
     title: { control: 'text' },
     content: { control: 'text' },
@@ -74,6 +82,7 @@ Presents a sequence that leads the user through well-defined steps within a page
   args={{
     isCompleted: true,
     isStarted: true,
+    isEditable: false,
     stepText: 'Step 1 of 6',
     title: 'Title',
     content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,
@@ -93,6 +102,7 @@ A completed step has a green check mark icon and an Edit-button which allows the
     args={{
       isCompleted: true,
       isStarted: true,
+      isEditable: false,
       stepText: 'Step 1 of 6',
       title: 'Title',
       content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,
@@ -112,6 +122,7 @@ The current step is the one the user is currently interacting with.
     args={{
       isCompleted: false,
       isStarted: true,
+      isEditable: false,
       stepText: 'Step 2 of 6',
       title: 'Title',
       content: `<div class="form-group">
@@ -140,6 +151,7 @@ An upcoming step only shows the title and step number, but hides the details in 
     args={{
       isCompleted: false,
       isStarted: false,
+      isEditable: false,
       stepText: 'Step 3 of 6',
       title: 'Title',
       content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,

--- a/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
+++ b/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
@@ -82,7 +82,7 @@ Presents a sequence that leads the user through well-defined steps within a page
   args={{
     isCompleted: true,
     isStarted: true,
-    isEditable: false,
+    isEditable: true,
     stepText: 'Step 1 of 6',
     title: 'Title',
     content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,
@@ -96,13 +96,15 @@ Presents a sequence that leads the user through well-defined steps within a page
 
 A completed step has a green check mark icon and an Edit-button which allows the user to change previously entered information.
 
+Use the `.editable` class in the container element to display the Edit button.
+
 <Canvas>
   <Story
     name="Completed step"
     args={{
       isCompleted: true,
       isStarted: true,
-      isEditable: false,
+      isEditable: true,
       stepText: 'Step 1 of 6',
       title: 'Title',
       content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,
@@ -122,7 +124,7 @@ The current step is the one the user is currently interacting with.
     args={{
       isCompleted: false,
       isStarted: true,
-      isEditable: false,
+      isEditable: true,
       stepText: 'Step 2 of 6',
       title: 'Title',
       content: `<div class="form-group">
@@ -151,7 +153,7 @@ An upcoming step only shows the title and step number, but hides the details in 
     args={{
       isCompleted: false,
       isStarted: false,
-      isEditable: false,
+      isEditable: true,
       stepText: 'Step 3 of 6',
       title: 'Title',
       content: `<dl class="gds-list"><dt>Sub title</dt><dd>Sub section text</dd><dt>Sub title</dt><dd>Sub section text</dd></dl>`,

--- a/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
+++ b/libs/chlorophyll/scss/components/wizard/in-page/in-page-wizard.stories.mdx
@@ -31,19 +31,16 @@ export const Template = ({
         }
       </header>
       ${
-        isStarted
-          ? `
-      <div class="gds-in-page-wizard-step-card__content">${content}</div>
-      ${
-        !isCompleted
-          ? `
-      <footer class="gds-in-page-wizard-step-card__footer">
-        <button class="primary">Next</button>
-      </footer>
-      `
-          : ''
-      }
-      `
+        isStarted ? 
+        `<div class="gds-in-page-wizard-step-card__content">${content}</div>
+          <footer class="gds-in-page-wizard-step-card__footer">
+            ${isCompleted ? 
+              `<button class="secondary">Edit</button>`
+              :
+              `<button class="primary">Next</button>`
+            }
+          </footer>
+        `
           : ''
       }
     </section>


### PR DESCRIPTION
### Issue

Closes: [#922](https://github.com/sebgroup/green/issues/922)

### Preview

#### Completed, editable step

<img width="431" alt="image" src="https://github.com/sebgroup/green/assets/82629695/22be2740-e5a6-49e7-814d-bcf7a3e3c3a4">

#### Completed, non-editable step

<img width="397" alt="image" src="https://github.com/sebgroup/green/assets/82629695/ca631277-4c25-4d25-a6f7-888fdcf5ddd0">
