### PR TITLE
fix(dropdown): fix mobile view and add backdrop

### DIFF
--- a/apps/core-lib-dev/project.json
+++ b/apps/core-lib-dev/project.json
@@ -45,7 +45,8 @@
       "executor": "@nx/webpack:dev-server",
       "options": {
         "buildTarget": "core-lib-dev:build",
-        "port": 4210
+        "port": 4210,
+        "host": "0.0.0.0"
       },
       "configurations": {
         "production": {

--- a/libs/core/project.json
+++ b/libs/core/project.json
@@ -59,7 +59,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build-with-types"],
+      "dependsOn": ["build-with-types-and-scoping"],
       "options": {
         "command": "npx wtr --node-resolve --playwright --browsers chromium firefox webkit"
       }

--- a/libs/core/src/components/dropdown/dropdown.stories.mdx
+++ b/libs/core/src/components/dropdown/dropdown.stories.mdx
@@ -11,14 +11,17 @@ import { registerTransitionalStyles } from '../../../../../dist/libs/core/src/tr
 
 <Canvas>
   <div style={{ height: '200px', dummy: registerTransitionalStyles() }}>
-    <gds-dropdown onchange="document.getElementById('selected-value').innerText = event.target.value">
-      <gds-option value="v1">value 1</gds-option>
-      <gds-option value="v2">Value 2</gds-option>
-      <gds-option value="v3">Value 3</gds-option>
+    <gds-dropdown
+      onchange="document.getElementById('selected-value').innerText = event.target.value"
+      label="Select food"
+    >
+      <gds-option value="pizza">Pizza</gds-option>
+      <gds-option value="spaghetti">Spaghetti</gds-option>
+      <gds-option value="mozarella">Mozarella</gds-option>
     </gds-dropdown>
     <br />
     <div>
-      Selected value: <span id="selected-value"></span>
+      Selected food: <span id="selected-value"></span>
     </div>
   </div>
 </Canvas>
@@ -29,16 +32,19 @@ import { registerTransitionalStyles } from '../../../../../dist/libs/core/src/tr
   <div style={{ height: '200px' }}>
     <gds-dropdown
       multiple
+      label="Pick team members"
       onchange="document.getElementById('selected-values').innerText = event.target.value.toString()"
     >
-      <gds-option isPlaceholder>Select values</gds-option>
-      <gds-option value="v1">value 1</gds-option>
-      <gds-option value="v2">Value 2</gds-option>
-      <gds-option value="v3">Value 3</gds-option>
+      <gds-option isPlaceholder>Select people</gds-option>
+      <gds-option value="einstein">Albert Einstein</gds-option>
+      <gds-option value="tesla">Nikola Tesla</gds-option>
+      <gds-option value="curie">Marie Curie</gds-option>
+      <gds-option value="darwin">Charles Darwin</gds-option>
+      <gds-option value="newton">Isaac Newton</gds-option>
     </gds-dropdown>
     <br />
     <div>
-      Selected values: <span id="selected-values"></span>
+      Selected team: <span id="selected-values"></span>
     </div>
   </div>
 </Canvas>
@@ -47,7 +53,7 @@ import { registerTransitionalStyles } from '../../../../../dist/libs/core/src/tr
 
 <Canvas>
   <div style={{ height: '300px', dummy: registerTransitionalStyles() }}>
-    <gds-dropdown searchable>
+    <gds-dropdown searchable label="Select tech">
       <gds-option value="">Select tech</gds-option>
       <gds-option value="warp">Warp Drive</gds-option>
       <gds-option value="cybernetics">Cybernetics</gds-option>
@@ -71,7 +77,7 @@ the default trigger content will be overridden, and you will have to manage the 
         <b>Selected: </b>
         <span id="trigger-value">v1</span>
       </div>
-      <gds-option value="v1">value 1</gds-option>
+      <gds-option value="v1">Value 1</gds-option>
       <gds-option value="v2">Value 2</gds-option>
       <gds-option value="v3">Value 3</gds-option>
     </gds-dropdown>

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -331,22 +331,7 @@ describe('<gds-dropdown>', () => {
     expect(el.open).to.be.false
   })
 
-  it('should close when focusing outside', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown open>
-        <gds-option>Option 1</gds-option>
-        <gds-option>Option 2</gds-option>
-        <gds-option>Option 3</gds-option>
-      </gds-dropdown>
-      <button id="test-button">Test</button>
-    `)
-    const testButton = document.getElementById('test-button')!
 
-    el.focus()
-    await el.updateComplete
-
-    testButton.focus()
-    await el.updateComplete
 
     expect(el.open).to.be.false
   })

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -319,6 +319,31 @@ describe('<gds-dropdown> keyboard navigation', () => {
     expect(document.activeElement).to.equal(secondOption)
   })
 
+  it('should focus option using keyboard navigation when opened with click', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown>
+        <gds-option value="v1">Option 1</gds-option>
+        <gds-option value="v2">Option 2</gds-option>
+        <gds-option value="v3">Option 3</gds-option>
+      </gds-dropdown>
+    `)
+
+    const trigger = el.shadowRoot!.querySelector<HTMLElement>('button')!
+
+    await clickOnElement(trigger, 'center')
+    await el.updateComplete
+
+    expect(el.open).to.be.true
+
+    await sendKeys({ press: 'ArrowDown' })
+    await timeout(50)
+    await sendKeys({ press: 'Enter' })
+    await timeout(50)
+
+    expect(el.value).to.equal('v2')
+    expect(el.open).to.be.false
+  })
+
   it('should select option with Enter key', async () => {
     const el = await fixture<GdsDropdown>(html`
       <gds-dropdown>

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -169,6 +169,120 @@ describe('<gds-dropdown>', () => {
     expect(uiStateHandler).to.have.been.calledTwice
   })
 
+  it('should react to changes in contained light DOM', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown>
+        <gds-option value="v1">Option 1</gds-option>
+        <gds-option value="v2">Option 2</gds-option>
+        <gds-option value="v3">Option 3</gds-option>
+      </gds-dropdown>
+    `)
+
+    const option1 = el.querySelectorAll(getScopedTagName('gds-option'))[0]
+    el.removeChild(option1)
+    await el.updateComplete
+
+    expect(el.options.length).to.equal(2)
+    expect(el.options[0].value).to.equal('v2')
+    expect(el.value).to.equal('v2')
+    expect(el.displayValue).to.equal('Option 2')
+  })
+
+  it('should register as a form control and have a FormData value', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <form id="test-form">
+        <gds-dropdown name="test-dropdown">
+          <gds-option value="v1">Option 1</gds-option>
+          <gds-option value="v2">Option 2</gds-option>
+          <gds-option value="v3">Option 3</gds-option>
+        </gds-dropdown>
+      </form>
+    `)
+    const form = document.getElementById('test-form')! as HTMLFormElement
+    const formData = new FormData(form)
+
+    expect((form.elements[0] as GdsDropdown).value).to.equal('v1')
+    expect(formData.get('test-dropdown')).to.equal('v1')
+  })
+})
+
+describe('<gds-dropdown> interactions', () => {
+  it('should open on click', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown>
+        <gds-option>Option 1</gds-option>
+        <gds-option>Option 2</gds-option>
+        <gds-option>Option 3</gds-option>
+      </gds-dropdown>
+    `)
+
+    const trigger = el.shadowRoot!.querySelector<HTMLElement>('button')!
+
+    await clickOnElement(trigger, 'center')
+    await el.updateComplete
+
+    expect(el.open).to.be.true
+  })
+
+  it('should select option on click', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown open>
+        <gds-option value="v1">Option 1</gds-option>
+        <gds-option value="v2">Option 2</gds-option>
+        <gds-option value="v3">Option 3</gds-option>
+      </gds-dropdown>
+    `)
+    await timeout(0)
+
+    const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
+
+    await clickOnElement(option2, 'center')
+    await el.updateComplete
+
+    expect(el.value).to.equal('v2')
+  })
+
+  it('should emit `change` event when option is selected', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown open>
+        <gds-option value="v1">Option 1</gds-option>
+        <gds-option value="v2">Option 2</gds-option>
+        <gds-option value="v3">Option 3</gds-option>
+      </gds-dropdown>
+    `)
+    await timeout(0)
+
+    const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
+
+    const changeHandler = sinon.spy()
+    el.addEventListener('change', changeHandler)
+
+    await clickOnElement(option2, 'center')
+    await el.updateComplete
+
+    await waitUntil(() => changeHandler.calledOnce)
+
+    expect(changeHandler).to.have.been.calledOnce
+    expect(changeHandler.firstCall.args[0].detail.value).to.equal('v2')
+  })
+
+  it('should close on click outside', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown open>
+        <gds-option>Option 1</gds-option>
+        <gds-option>Option 2</gds-option>
+        <gds-option>Option 3</gds-option>
+      </gds-dropdown>
+    `)
+
+    await sendMouse({ type: 'click', position: [0, 0] })
+    await el.updateComplete
+
+    expect(el.open).to.be.false
+  })
+})
+
+describe('<gds-dropdown> keyboard navigation', () => {
   it('should open on arrow navigation', async () => {
     const el = await fixture<GdsDropdown>(html`
       <gds-dropdown>
@@ -245,65 +359,6 @@ describe('<gds-dropdown>', () => {
     expect(el.value).to.equal('v2')
   })
 
-  it('should open on click', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown>
-        <gds-option>Option 1</gds-option>
-        <gds-option>Option 2</gds-option>
-        <gds-option>Option 3</gds-option>
-      </gds-dropdown>
-    `)
-
-    const trigger = el.shadowRoot!.querySelector<HTMLElement>('button')!
-
-    await clickOnElement(trigger, 'center')
-    await el.updateComplete
-
-    expect(el.open).to.be.true
-  })
-
-  it('should select option on click', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown open>
-        <gds-option value="v1">Option 1</gds-option>
-        <gds-option value="v2">Option 2</gds-option>
-        <gds-option value="v3">Option 3</gds-option>
-      </gds-dropdown>
-    `)
-    await timeout(0)
-
-    const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
-
-    await clickOnElement(option2, 'center')
-    await el.updateComplete
-
-    expect(el.value).to.equal('v2')
-  })
-
-  it('should emit `change` event when option is selected', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown open>
-        <gds-option value="v1">Option 1</gds-option>
-        <gds-option value="v2">Option 2</gds-option>
-        <gds-option value="v3">Option 3</gds-option>
-      </gds-dropdown>
-    `)
-    await timeout(0)
-
-    const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
-
-    const changeHandler = sinon.spy()
-    el.addEventListener('change', changeHandler)
-
-    await clickOnElement(option2, 'center')
-    await el.updateComplete
-
-    await waitUntil(() => changeHandler.calledOnce)
-
-    expect(changeHandler).to.have.been.calledOnce
-    expect(changeHandler.firstCall.args[0].detail.value).to.equal('v2')
-  })
-
   it('should close on ESC', async () => {
     const el = await fixture<GdsDropdown>(html`
       <gds-dropdown open>
@@ -318,57 +373,6 @@ describe('<gds-dropdown>', () => {
     await el.updateComplete
 
     expect(el.open).to.be.false
-  })
-
-  it('should close on click outside', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown open>
-        <gds-option>Option 1</gds-option>
-        <gds-option>Option 2</gds-option>
-        <gds-option>Option 3</gds-option>
-      </gds-dropdown>
-    `)
-
-    await sendMouse({ type: 'click', position: [0, 0] })
-    await el.updateComplete
-
-    expect(el.open).to.be.false
-  })
-
-  it('should react to changes in contained light DOM', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown>
-        <gds-option value="v1">Option 1</gds-option>
-        <gds-option value="v2">Option 2</gds-option>
-        <gds-option value="v3">Option 3</gds-option>
-      </gds-dropdown>
-    `)
-
-    const option1 = el.querySelectorAll(getScopedTagName('gds-option'))[0]
-    el.removeChild(option1)
-    await el.updateComplete
-
-    expect(el.options.length).to.equal(2)
-    expect(el.options[0].value).to.equal('v2')
-    expect(el.value).to.equal('v2')
-    expect(el.displayValue).to.equal('Option 2')
-  })
-
-  it('should register as a form control and have a FormData value', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <form id="test-form">
-        <gds-dropdown name="test-dropdown">
-          <gds-option value="v1">Option 1</gds-option>
-          <gds-option value="v2">Option 2</gds-option>
-          <gds-option value="v3">Option 3</gds-option>
-        </gds-dropdown>
-      </form>
-    `)
-    const form = document.getElementById('test-form')! as HTMLFormElement
-    const formData = new FormData(form)
-
-    expect((form.elements[0] as GdsDropdown).value).to.equal('v1')
-    expect(formData.get('test-dropdown')).to.equal('v1')
   })
 })
 

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -410,29 +410,6 @@ describe('<gds-dropdown searchable>', () => {
     expect(options.length).to.equal(1)
     expect(options[0].textContent).to.equal('Option 2')
   })
-
-  it('should filter options when typing in search field', async () => {
-    const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown searchable open>
-        <gds-option>Option 1</gds-option>
-        <gds-option>Option 2</gds-option>
-        <gds-option>Option 3</gds-option>
-      </gds-dropdown>
-    `)
-    const searchField =
-      el.shadowRoot!.querySelector<HTMLElement>('input[type=text]')!
-
-    searchField.focus()
-    await sendKeys({ type: '2' })
-    await el.updateComplete
-
-    const options = el.querySelectorAll(
-      `${getScopedTagName('gds-option')}:not([aria-hidden="true"])`
-    )
-
-    expect(options.length).to.equal(1)
-    expect(options[0].textContent).to.equal('Option 2')
-  })
 })
 
 describe('<gds-dropdown multiple>', () => {

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -270,6 +270,8 @@ describe('<gds-dropdown>', () => {
         <gds-option value="v3">Option 3</gds-option>
       </gds-dropdown>
     `)
+    await timeout(0)
+
     const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
 
     await clickOnElement(option2, 'center')
@@ -286,6 +288,8 @@ describe('<gds-dropdown>', () => {
         <gds-option value="v3">Option 3</gds-option>
       </gds-dropdown>
     `)
+    await timeout(0)
+
     const option2 = el.querySelectorAll(getScopedTagName('gds-option'))[1]
 
     const changeHandler = sinon.spy()
@@ -327,11 +331,6 @@ describe('<gds-dropdown>', () => {
 
     await sendMouse({ type: 'click', position: [0, 0] })
     await el.updateComplete
-
-    expect(el.open).to.be.false
-  })
-
-
 
     expect(el.open).to.be.false
   })
@@ -397,7 +396,7 @@ describe('<gds-dropdown searchable>', () => {
       </gds-dropdown>
     `)
     const searchField =
-      el.shadowRoot!.querySelector<HTMLElement>('input[type=text]')!
+      el.shadowRoot!.querySelector<HTMLInputElement>('input[type=text]')!
 
     searchField.focus()
     await sendKeys({ type: '2' })
@@ -415,7 +414,7 @@ describe('<gds-dropdown searchable>', () => {
 describe('<gds-dropdown multiple>', () => {
   it('should support multiple selections', async () => {
     const el = await fixture<GdsDropdown>(html`
-      <gds-dropdown multiple open>
+      <gds-dropdown multiple>
         <gds-option value="v1">Option 1</gds-option>
         <gds-option value="v2">Option 2</gds-option>
         <gds-option value="v3">Option 3</gds-option>
@@ -424,7 +423,7 @@ describe('<gds-dropdown multiple>', () => {
 
     el.focus()
     await sendKeys({ press: 'ArrowDown' })
-    await el.updateComplete
+    await timeout(50)
     await sendKeys({ press: 'ArrowDown' })
     await el.updateComplete
     await sendKeys({ press: 'Space' })

--- a/libs/core/src/components/dropdown/dropdown.trans.styles.scss
+++ b/libs/core/src/components/dropdown/dropdown.trans.styles.scss
@@ -26,6 +26,7 @@
 
 input[type='text'] {
   border-radius: 0;
+  font-size: 1rem;
   line-height: 1;
   margin: -1px;
   min-height: auto;

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -205,6 +205,7 @@ export class GdsDropdown<ValueT = any>
           ${ref(this.#listboxRef)}
           @change="${this.#handleSelectionChange}"
           @gds-focus="${this.#handleOptionFocusChange}"
+          @keydown=${this.#handleListboxKeyDown}
         >
           <slot gds-allow="gds-option"></slot>
         </gds-listbox>
@@ -265,12 +266,25 @@ export class GdsDropdown<ValueT = any>
   }
 
   /**
-   * Check for ArrowDown in the search field.
+   * Check for ArrowDown or Tab in the search field.
    * If found, focus should be moved to the listbox.
    */
   #handleSearchFieldKeyDown = (e: KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
+    if (e.key === 'ArrowDown' || e.key === 'Tab') {
+      e.preventDefault()
       this.#listboxRef.value?.focus()
+      return
+    }
+  }
+
+  /**
+   * Check for Tab in the listbox.
+   * If found, focus should be moved to the search field.
+   */
+  #handleListboxKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Tab' && this.searchable) {
+      e.preventDefault()
+      this.#searchInputRef.value?.focus()
       return
     }
   }
@@ -346,12 +360,14 @@ export class GdsDropdown<ValueT = any>
     window.addEventListener('click', this.#autoCloseListener)
     this.addEventListener('blur', this.#autoCloseListener)
     this.addEventListener('gds-blur', this.#autoCloseListener)
+    this.addEventListener('keydown', this.#tabCloseListener)
   }
 
   #unregisterAutoCloseListener() {
     window.removeEventListener('click', this.#autoCloseListener)
     this.removeEventListener('blur', this.#autoCloseListener)
     this.removeEventListener('gds-blur', this.#autoCloseListener)
+    this.removeEventListener('keydown', this.#tabCloseListener)
   }
 
   /**
@@ -370,5 +386,13 @@ export class GdsDropdown<ValueT = any>
       !this.contains(e.relatedTarget as Node)
 
     if (isClickOutside || isFocusOutside) this.open = false
+  }
+
+  #tabCloseListener = (e: KeyboardEvent) => {
+    if (e.key === 'Tab' && !this.searchable) {
+      e.preventDefault()
+      this.open = false
+      this.#triggerRef.value?.focus()
+    }
   }
 }

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -253,7 +253,7 @@ export class GdsDropdown<ValueT = any>
    * @param e The keyboard event.
    */
   #handleSearchFieldKeyUp = (e: KeyboardEvent) => {
-    const input = e.target as HTMLInputElement
+    const input = this.#searchInputRef.value!
     const options = Array.from(this.#optionElements)
     options.forEach((o) => (o.hidden = false))
 

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -340,11 +340,12 @@ export class GdsDropdown<ValueT = any>
   private _onOpenChange() {
     const open = this.open
 
+    Array.from(this.#optionElements).forEach((o) => (o.hidden = !open))
+
     if (open) this.#registerAutoCloseListener()
     else {
       this.#unregisterAutoCloseListener()
       this.#searchInputRef.value && (this.#searchInputRef.value.value = '')
-      Array.from(this.#optionElements).forEach((o) => (o.hidden = false))
     }
 
     this.dispatchEvent(

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -182,6 +182,7 @@ export class GdsDropdown<ValueT = any>
       <span class="form-info"><slot name="message"></slot></span>
 
       <gds-popover
+        .label=${this.label}
         .open=${this.open}
         @gds-ui-state=${(e: CustomEvent) => (this.open = e.detail.open)}
         ${ref(this.#registerPopoverTrigger)}

--- a/libs/core/src/primitives/listbox/option.trans.styles.scss
+++ b/libs/core/src/primitives/listbox/option.trans.styles.scss
@@ -5,6 +5,7 @@
   @include dropdown.select-option;
   display: flex;
   gap: 0.75rem;
+  user-select: none;
 }
 
 :host(:hover) {

--- a/libs/core/src/primitives/popover/popover.styles.ts
+++ b/libs/core/src/primitives/popover/popover.styles.ts
@@ -6,6 +6,10 @@ const style = css`
     background-color: white;
     box-shadow: 0 1rem 1rem 1rem rgba(0, 0, 0, 0.1);
   }
+
+  dialog::backdrop {
+    pointer-events: none;
+  }
 `
 
 export default style

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -9,8 +9,9 @@
 }
 
 header {
+  border-bottom: 1px solid var(--border-color);
   display: flex;
-  padding: 0.75rem;
+  padding: 0.5rem 0.75rem;
 
   @include common.media-breakpoint-up('sm') {
     display: none;

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -1,12 +1,8 @@
 @use '../../../../chlorophyll/scss/components/popover/mixins' as popover;
 @use '../../../../chlorophyll/scss/components/close';
+@use '../../../../chlorophyll/scss/common';
 
-div {
-  @include popover.popover;
-  overflow: hidden;
-}
-
-:host([open]) div {
+:host([open]) dialog {
   opacity: 1;
   transform: translate3d(0, 0, 0);
   visibility: visible;
@@ -15,6 +11,10 @@ div {
 header {
   display: flex;
   padding: 0.75rem;
+
+  @include common.media-breakpoint-up('sm') {
+    display: none;
+  }
 }
 
 header h2 {
@@ -25,9 +25,20 @@ header h2 {
 }
 
 dialog {
+  @include popover.popover;
   border-width: 0;
+  overflow: hidden;
   padding: 0;
-  position: static;
+  right: 0;
+
+  @include common.media-breakpoint-down('sm') {
+    border-radius: 1rem;
+  }
+
+  @include common.media-breakpoint-up('sm') {
+    inset: auto;
+    position: absolute;
+  }
 }
 
 dialog::backdrop {
@@ -35,4 +46,7 @@ dialog::backdrop {
   display: block;
   pointer-events: none;
   position: fixed;
+  @include common.media-breakpoint-up('sm') {
+    display: none;
+  }
 }

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -1,12 +1,38 @@
 @use '../../../../chlorophyll/scss/components/popover/mixins' as popover;
+@use '../../../../chlorophyll/scss/components/close';
 
-:host {
+div {
   @include popover.popover;
   overflow: hidden;
 }
 
-:host([open]) {
+:host([open]) div {
   opacity: 1;
   transform: translate3d(0, 0, 0);
   visibility: visible;
+}
+
+header {
+  display: flex;
+  padding: 0.75rem;
+}
+
+header h2 {
+  flex-grow: 1;
+  font-weight: 500;
+  line-height: 1.5;
+  margin: 0;
+}
+
+dialog {
+  border-width: 0;
+  padding: 0;
+  position: static;
+}
+
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.2);
+  display: block;
+  pointer-events: none;
+  position: fixed;
 }

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -87,9 +87,23 @@ export class GdsPopover extends LitElement {
     this.setAttribute('aria-hidden', String(!this.open))
     this.hidden = !this.open
 
-    this.open
-      ? this.#dialogElementRef.value?.showModal()
-      : this.#dialogElementRef.value?.close()
+    if (this.open) {
+      this.#dialogElementRef.value?.showModal()
+      this.#dialogElementRef.value?.style.setProperty('opacity', '0')
+      this.#dialogElementRef.value?.style.setProperty(
+        'transform',
+        'translate3d(0px, 100%, 0px)'
+      )
+      setTimeout(() => {
+        this.#dialogElementRef.value?.style.setProperty('opacity', '1')
+        this.#dialogElementRef.value?.style.setProperty(
+          'transform',
+          'translate3d(0px, 0px, 0px)'
+        )
+      }, 0)
+    } else {
+      this.#dialogElementRef.value?.close()
+    }
 
     this.dispatchEvent(
       new CustomEvent('gds-ui-state', {

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -49,7 +49,6 @@ export class GdsPopover extends LitElement {
     this.#registerTriggerEvents()
   }
 
-  #popoverElementRef: Ref<HTMLDivElement> = createRef()
   #dialogElementRef: Ref<HTMLDialogElement> = createRef()
 
   connectedCallback(): void {

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -86,23 +86,11 @@ export class GdsPopover extends LitElement {
     this.setAttribute('aria-hidden', String(!this.open))
     this.hidden = !this.open
 
-    if (this.open) {
-      this.#dialogElementRef.value?.showModal()
-      this.#dialogElementRef.value?.style.setProperty('opacity', '0')
-      this.#dialogElementRef.value?.style.setProperty(
-        'transform',
-        'translate3d(0px, 100%, 0px)'
-      )
-      setTimeout(() => {
-        this.#dialogElementRef.value?.style.setProperty('opacity', '1')
-        this.#dialogElementRef.value?.style.setProperty(
-          'transform',
-          'translate3d(0px, 0px, 0px)'
-        )
-      }, 0)
-    } else {
-      this.#dialogElementRef.value?.close()
-    }
+    this.updateComplete.then(() => {
+      this.open
+        ? this.#dialogElementRef.value?.showModal()
+        : this.#dialogElementRef.value?.close()
+    })
 
     this.dispatchEvent(
       new CustomEvent('gds-ui-state', {

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -93,15 +93,15 @@ export class GdsPopover extends LitElement {
       } else {
         this.#dialogElementRef.value?.close()
       }
-
-      this.dispatchEvent(
-        new CustomEvent('gds-ui-state', {
-          detail: { open: this.open },
-          bubbles: true,
-          composed: false,
-        })
-      )
     })
+
+    this.dispatchEvent(
+      new CustomEvent('gds-ui-state', {
+        detail: { open: this.open },
+        bubbles: true,
+        composed: false,
+      })
+    )
   }
 
   #handleCloseButton = (e: MouseEvent) => {

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -63,7 +63,7 @@ export class GdsPopover extends LitElement {
 
     this.addEventListener('keydown', (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        this.#setOpen(false)
+        this.open = false
       }
     })
   }
@@ -100,6 +100,14 @@ export class GdsPopover extends LitElement {
       this.open
         ? this.#dialogElementRef.value?.showModal()
         : this.#dialogElementRef.value?.close()
+
+    this.dispatchEvent(
+      new CustomEvent('gds-ui-state', {
+        detail: { open: this.open },
+        bubbles: true,
+        composed: false,
+      })
+    )
   }
 
   @watchMediaQuery('(max-width: 576px)')
@@ -158,7 +166,7 @@ export class GdsPopover extends LitElement {
   #triggerKeyDownListener = (e: KeyboardEvent) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      this.#setOpen(true)
+      this.open = true
 
       const firstSlottedChild = this.shadowRoot
         ?.querySelector('slot')
@@ -169,18 +177,7 @@ export class GdsPopover extends LitElement {
       })
     }
     if (e.key === 'Escape') {
-      this.#setOpen(false)
+      this.open = false
     }
-  }
-
-  #setOpen(open: boolean) {
-    this.open = open
-    this.dispatchEvent(
-      new CustomEvent('gds-ui-state', {
-        detail: { open },
-        bubbles: true,
-        composed: false,
-      })
-    )
   }
 }

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -117,7 +117,6 @@ export class GdsPopover extends LitElement {
   @watchMediaQuery('(max-width: 576px)')
   private _handleMobileLayout(matches: boolean) {
     if (matches) {
-      //this._isMobileLayout = true
       this.#autoPositionCleanup?.()
       this.#dialogElementRef.value?.style.removeProperty('left')
       this.#dialogElementRef.value?.style.removeProperty('top')
@@ -126,7 +125,6 @@ export class GdsPopover extends LitElement {
         if (this.open) this.#dialogElementRef.value?.showModal()
       })
     } else {
-      //this._isMobileLayout = false
       this.updateComplete.then(() => {
         this.#registerAutoPositioning()
       })

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -92,6 +92,10 @@ export class GdsPopover extends LitElement {
         : this.#dialogElementRef.value?.close()
     })
 
+    if (this.open) {
+      this.#focusFirstSlottedChild()
+    }
+
     this.dispatchEvent(
       new CustomEvent('gds-ui-state', {
         detail: { open: this.open },
@@ -156,17 +160,22 @@ export class GdsPopover extends LitElement {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
       this.open = true
-
-      const firstSlottedChild = this.shadowRoot
-        ?.querySelector('slot')
-        ?.assignedElements()[0] as HTMLElement
-
-      this.updateComplete.then(() => {
-        firstSlottedChild?.focus()
-      })
     }
     if (e.key === 'Escape') {
       this.open = false
     }
+  }
+
+  /**
+   * Move focus to the first slotted child.
+   */
+  #focusFirstSlottedChild = () => {
+    const firstSlottedChild = this.shadowRoot
+      ?.querySelector('slot')
+      ?.assignedElements()[0] as HTMLElement
+
+    this.updateComplete.then(() => {
+      firstSlottedChild?.focus()
+    })
   }
 }

--- a/libs/core/src/utils/decorators/index.ts
+++ b/libs/core/src/utils/decorators/index.ts
@@ -1,2 +1,3 @@
 export * from './watch'
 export * from './observe-light-dom'
+export * from './watch-media-query'

--- a/libs/core/src/utils/decorators/watch-media-query.ts
+++ b/libs/core/src/utils/decorators/watch-media-query.ts
@@ -1,0 +1,61 @@
+import type { LitElement } from 'lit'
+
+type Handler = (matches: boolean) => void
+
+/**
+ * Media queries expressing standard breakpoints.
+ * TODO: These should probably be imported from somehere, so that they are always in sync with CSS.
+ */
+export const standardBreakpoints = {
+  sm: '(min-width: 576px)',
+  md: '(min-width: 768px)',
+  lg: '(min-width: 1024px)',
+  xl: '(min-width: 1280px)',
+}
+
+/**
+ * Runs when the match state of the specified media query changes.
+ *
+ * @param q The media query to watch.
+ *
+ * Usage:
+ * ```javascript
+ * \@watchMediaQuery('(max-width: 576px)')
+ * handleMobileLayout(matches) {
+ *  if (matches) {
+ *   // Do something when the media query matches
+ *  } else
+ *   // Do something when the media query no longer matches
+ *  }
+ * }
+ * ```
+ */
+export function watchMediaQuery(q: string) {
+  return <ElemClass extends LitElement>(
+    proto: ElemClass,
+    _propertyKey: string,
+    descriptor: TypedPropertyDescriptor<Handler>
+  ) => {
+    const mediaQuery = window.matchMedia(q)
+
+    const connectedCallback = proto.connectedCallback
+    const disconnectedCallback = proto.disconnectedCallback
+
+    proto.connectedCallback = function (this: ElemClass) {
+      connectedCallback?.call(this)
+
+      const listener = (e: MediaQueryListEvent) => {
+        descriptor.value?.call(this, e.matches)
+      }
+
+      mediaQuery.addEventListener('change', listener)
+
+      this.disconnectedCallback = function (this: ElemClass) {
+        disconnectedCallback?.call(this)
+        mediaQuery.removeEventListener('change', listener)
+      }
+
+      descriptor.value?.call(this, mediaQuery.matches)
+    }
+  }
+}


### PR DESCRIPTION
Related: #862

This PR corrects the mobile layout of the popover and adds a backdrop.

Since the mobile version is designed to work as a modal, I figured that the native modal `<dialog>` would be suitable here. It also gives us access to the `:backdrop` pseudo element, and makes use of the `#top-layer` stacking context.

A caveat is that it makes the view structure of the popover different in mobile view, meaning that we have to rely on media query events to update the view accordingly, which feels a bit "hacky". But since it is a small and simple component (the `gds-popover`), I think we can live with it.

Other options that could simplify it would be:

* Use the modal approach for larger (desktop) view as well (not visually, only semantically). This would make the rest of the page inaccessible while the popover is open, forcing the user to abort or make a choice before they do anything else. Focus would be trapped in the popover.

* Get rid of the mobile-specific layout and just use the regular popover in all viewports, and keep it always non-modal.

I'm not sure what the most a11y-friendly solution is. There are trade-offs either way. For now though, it should at least be an improvement over the current implementation, and we can always change it later.