### PR TITLE
feat(charts): custom colours

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -13,7 +13,6 @@ module.exports = {
 
   addons: [
     '@storybook/addon-links',
-
     '@storybook/addon-a11y',
     'storybook-dark-mode',
     path.resolve('./.storybook/addons/run-in-iframe/run-in-iframe-preset.js'),

--- a/libs/angular-charts/.storybook/preview.js
+++ b/libs/angular-charts/.storybook/preview.js
@@ -1,5 +1,5 @@
 import { parameters as baseParameters } from '../../../.storybook/preview'
-// import '!style-loader!css-loader!postcss-loader!sass-loader!./scss-loader.scss'
+import '!style-loader!css-loader!postcss-loader!sass-loader!./preview.scss'
 
 export const parameters = {
   ...baseParameters,

--- a/libs/angular-charts/.storybook/preview.scss
+++ b/libs/angular-charts/.storybook/preview.scss
@@ -1,6 +1,6 @@
 // load global styles used by storybook
 @use '../../chlorophyll/scss' with (
-  $font-path: '.'
+  $font-path: '../../../dist/fonts'
 );
 
 @use '../../charts/scss' as charts;

--- a/libs/angular-charts/src/lib/chart/chart.stories.ts
+++ b/libs/angular-charts/src/lib/chart/chart.stories.ts
@@ -19,7 +19,7 @@ export default {
 
 const ChartStory: Story<NggChartComponent> = (args) => ({
   props: args,
-  template: `<ngg-chart [settings]='settings' [theme]='theme'></ngg-chart>`,
+  template: `<ngg-chart [settings]="settings" [theme]="theme"></ngg-chart>`,
 })
 
 const ChartCardStory: Story<NggChartComponent> = (args) => ({
@@ -27,14 +27,14 @@ const ChartCardStory: Story<NggChartComponent> = (args) => ({
   template: `<div class="card" style="height: 340px">
                 <header><h3>Chart in card with locked height (340px)</h3></header>
                 <div>
-                    <ngg-chart [settings]='settings' [theme]='theme'></ngg-chart>
+                    <ngg-chart [settings]="settings" [theme]="theme"></ngg-chart>
                 </div>
              </div>`,
 })
 
 const ObservableChartStory: Story<NggChartComponent> = (args) => ({
   props: args,
-  template: `<ngg-chart [settings]='settings | async' [theme]='theme'></ngg-chart>`,
+  template: `<ngg-chart [settings]="settings | async" [theme]="theme"></ngg-chart>`,
 })
 
 export const SimpleBar = ChartStory.bind({})
@@ -137,11 +137,6 @@ Donut.args = {
         values: [100],
       },
     ],
-    style: {
-      color: {
-        pattern: ['#dadada', '#000000', 'green'],
-      },
-    },
   },
   theme: '',
 }
@@ -370,6 +365,29 @@ MixedGraphWithNegativeValues.args = {
       'dec',
     ],
     legend: 'top',
+  },
+  theme: '',
+}
+
+export const CustomColours = ChartStory.bind({})
+CustomColours.args = {
+  settings: {
+    type: 'donut',
+    data: [
+      {
+        name: 'Ej tilldelade',
+        values: [600],
+      },
+      {
+        name: 'Tilldelade',
+        values: [100],
+      },
+    ],
+    style: {
+      color: {
+        pattern: ['#dadada', '#45B400'],
+      },
+    },
   },
   theme: '',
 }

--- a/libs/angular-charts/src/lib/chart/chart.stories.ts
+++ b/libs/angular-charts/src/lib/chart/chart.stories.ts
@@ -137,6 +137,11 @@ Donut.args = {
         values: [100],
       },
     ],
+    style: {
+      color: {
+        pattern: ['#dadada', '#000000', 'green'],
+      },
+    },
   },
   theme: '',
 }

--- a/libs/charts/src/lib/billboard.ts
+++ b/libs/charts/src/lib/billboard.ts
@@ -40,6 +40,7 @@ export const createOptions = ({
   const columns = settings.data.map((d) => [d.name, ...d.values])
 
   const defaultType: ChartType = settings.type || 'bar'
+
   const types = settings.data.reduce(
     (res, d) => ({
       ...res,
@@ -55,8 +56,11 @@ export const createOptions = ({
     {}
   )
 
+  const color = Object.assign({}, settings.style?.color)
+
   const defaultTooltipNumberFormat = (num: number) =>
     num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
+
   const options: ChartOptions = {
     bindto: chartElement,
     data: {
@@ -79,9 +83,11 @@ export const createOptions = ({
       },
       contents: { template: tmplTooltip },
     },
+    color,
   }
 
   let hasY2Axis = false
+
   hasY2Axis = Object.values(axes).indexOf('y2') !== -1
 
   if (hasY2Axis) {
@@ -248,6 +254,7 @@ export const createInfo = (
 
 export const create = ({ settings, chartElement }: ChartArgs): Chart => {
   const options = createOptions({ settings, chartElement })
+  console.log(options)
   const chart = bb.generate(options)
   const info = createInfo(settings, chart)
 

--- a/libs/charts/src/lib/billboard.ts
+++ b/libs/charts/src/lib/billboard.ts
@@ -254,7 +254,6 @@ export const createInfo = (
 
 export const create = ({ settings, chartElement }: ChartArgs): Chart => {
   const options = createOptions({ settings, chartElement })
-  console.log(options)
   const chart = bb.generate(options)
   const info = createInfo(settings, chart)
 

--- a/libs/charts/src/lib/types.ts
+++ b/libs/charts/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { ArrayOrString } from 'billboard.js'
+import { ChartOptions } from 'billboard.js/types/options'
 
 export type ChartType = 'area' | 'bar' | 'donut' | 'line' | 'spline' | 'pie'
 export type LegendPlacement = 'top' | 'right' | 'none'
@@ -44,7 +45,7 @@ export interface ChartAxis {
   }
 }
 
-export interface ChartStyle {
+export interface ChartStyle extends Pick<ChartOptions, 'color'> {
   fitHeightToParent?: boolean
   axis?:
     | boolean

--- a/libs/react-charts/.storybook/preview.scss
+++ b/libs/react-charts/.storybook/preview.scss
@@ -1,2 +1,8 @@
 // load global styles used by storybook
+@use '../../chlorophyll/scss' with (
+  $font-path: '../../../dist/fonts'
+);
+
 @use '../../charts/scss' as charts;
+
+@use '../../../.storybook/storybook-overrides';

--- a/libs/react-charts/src/lib/chart.stories.tsx
+++ b/libs/react-charts/src/lib/chart.stories.tsx
@@ -153,3 +153,25 @@ Mixed.args = {
     legend: 'right',
   },
 }
+
+export const CustomColours = Template.bind({})
+CustomColours.args = {
+  settings: {
+    type: 'donut',
+    data: [
+      {
+        name: 'Ej tilldelade',
+        values: [700],
+      },
+      {
+        name: 'Tilldelade',
+        values: [300],
+      },
+    ],
+    style: {
+      color: {
+        pattern: ['#dadada', 'green'],
+      },
+    },
+  },
+}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@babel/core": "^7.17.9",
     "@babel/plugin-proposal-decorators": "^7.17.9",
     "@babel/plugin-proposal-export-default-from": "^7.16.7",
-    "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.16.7",
@@ -106,6 +106,7 @@
     "@lit/localize-tools": "^0.6.9",
     "@nrwl/esbuild": "16.8.1",
     "@nrwl/storybook": "16.8.1",
+    "@nx/angular": "16.8.1",
     "@nx/devkit": "16.8.1",
     "@nx/esbuild": "16.8.1",
     "@nx/eslint-plugin": "16.8.1",
@@ -232,8 +233,7 @@
     "vitest": "0.31.4",
     "webpack": "5.88.2",
     "webpack-merge": "^5.8.0",
-    "yarn-audit-fix": "^9.2.4",
-    "@nx/angular": "16.8.1"
+    "yarn-audit-fix": "^9.2.4"
   },
   "resolutions": {
     "async": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,10 +1249,20 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
 
-"@babel/plugin-proposal-private-property-in-object@^7.12.1", "@babel/plugin-proposal-private-property-in-object@^7.16.7", "@babel/plugin-proposal-private-property-in-object@^7.18.6", "@babel/plugin-proposal-private-property-in-object@^7.21.0":
+"@babel/plugin-proposal-private-property-in-object@^7.12.1", "@babel/plugin-proposal-private-property-in-object@^7.18.6", "@babel/plugin-proposal-private-property-in-object@^7.21.0":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz#19496bd9883dd83c23c7d7fc45dcd9ad02dfa1dc"
   integrity sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-create-class-features-plugin" "^7.21.0"


### PR DESCRIPTION
You can now pass a [color object](https://naver.github.io/billboard.js/release/latest/doc/Options.html#.color) in the styles object in settings for the chart.

This makes it possible to override the default theme where needed.