### PR TITLE
fix(chlorophyll): only import tokens in use-green-scope

### DIFF
--- a/libs/chlorophyll/scss/components/use-green-scope/_index.scss
+++ b/libs/chlorophyll/scss/components/use-green-scope/_index.scss
@@ -5,9 +5,7 @@ $font-path: '../fonts' !default;
 );
 
 @use '../../tokens/colors';
-@use '../../components/form/radio';
-@use '../../components/form/checkbox';
-@use '../../components/filter-chip';
+@use '../../tokens/components';
 @use '../../tokens/shape';
 
 @use '../reset/mixins' as mixins;
@@ -17,10 +15,10 @@ $font-path: '../fonts' !default;
 .use-green {
   @include shape.add-tokens();
   @include colors.add-color-tokens();
-  @include radio.add-radio-tokens();
-  @include filter-chip.filter-chip-tokens();
-  @include checkbox.add-checkbox-tokens();
-  @include tokens.light-mode;
+  @include components.add-radio-tokens();
+  @include components.filter-chip-tokens();
+  @include components.add-checkbox-tokens();
+  @include tokens.light-mode();
   @include themes.add-theme();
 }
 

--- a/libs/chlorophyll/scss/tokens/_components.scss
+++ b/libs/chlorophyll/scss/tokens/_components.scss
@@ -1,3 +1,3 @@
-@forward '../components/form/radio';
-@forward '../components/form/checkbox';
-@forward '../components/filter-chip';
+@forward '../components/form/radio/tokens';
+@forward '../components/form/checkbox/tokens';
+@forward '../components/filter-chip/tokens';


### PR DESCRIPTION
radio/checkbox/filter styles are added outside of the .use-green scope. 

@use '...tokens/component' causes its styles to be imported. Only the tokens should be imported. 