### PR TITLE
feat(slider): change to a text input with `inputmode='numeric'`

### DIFF
--- a/libs/angular/src/lib/slider/slider.component.html
+++ b/libs/angular/src/lib/slider/slider.component.html
@@ -36,7 +36,9 @@
 
 <ng-template #inputField>
   <input
-    type="number"
+    type="text"
+    inputmode="numeric"
+    pattern="[0-9]*"
     [(ngModel)]="value"
     [class.is-invalid]="!!errorMessage"
     [attr.name]="name"

--- a/libs/angular/src/lib/slider/slider.component.html
+++ b/libs/angular/src/lib/slider/slider.component.html
@@ -36,7 +36,7 @@
 
 <ng-template #inputField>
   <input
-    type="text"
+    type="number"
     inputmode="numeric"
     pattern="[0-9]*"
     [(ngModel)]="value"

--- a/libs/angular/src/lib/slider/slider.component.html
+++ b/libs/angular/src/lib/slider/slider.component.html
@@ -45,6 +45,7 @@
     [attr.id]="name + '-textbox'"
     [attr.placeholder]="placeholder"
     [attr.aria-labelledby]="name + '-label'"
+    [attr.enterkeyhint]="enterkeyhint"
     [disabled]="disabled"
     (blur)="onBlur()"
     (input)="handleChange()"

--- a/libs/angular/src/lib/slider/slider.component.html
+++ b/libs/angular/src/lib/slider/slider.component.html
@@ -36,7 +36,7 @@
 
 <ng-template #inputField>
   <input
-    type="number"
+    type="text"
     inputmode="numeric"
     pattern="[0-9]*"
     [(ngModel)]="value"

--- a/libs/angular/src/lib/slider/slider.component.ts
+++ b/libs/angular/src/lib/slider/slider.component.ts
@@ -46,6 +46,14 @@ export class NggSliderComponent
   @Input() unitLabel = 'kr'
   @Input() disabled = false
   @Input() value = 0
+  @Input() enterkeyhint?:
+    | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send'
 
   @Output() sliderChange = new EventEmitter<number>()
   @Output() sliderTouch = new EventEmitter<boolean>()

--- a/libs/react/src/lib/slider/slider.spec.tsx
+++ b/libs/react/src/lib/slider/slider.spec.tsx
@@ -95,7 +95,7 @@ describe('Slider', () => {
       />
     )
     const inputField = container.querySelector(
-      'input[type=number]'
+      'input[type=text]'
     ) as HTMLInputElement
     fireEvent.blur(inputField, { target: { value: '' } })
     expect(onChange).toBeCalledWith(10)

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -124,7 +124,7 @@ export function Slider({
         {hasTextbox && (
           <InputWrapper unitLabel={unitLabel}>
             <input
-              type="text"
+              type="number"
               inputMode="numeric"
               pattern="[0-9]*"
               value={inputFieldValue}

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -113,7 +113,9 @@ export function Slider({
         <div>
           {label && (
             <>
-              <label htmlFor={name} id={`${name}-label`}>{label}</label>
+              <label htmlFor={name} id={`${name}-label`}>
+                {label}
+              </label>
               {instruction && <p>{instruction}</p>}
             </>
           )}
@@ -121,7 +123,9 @@ export function Slider({
         {hasTextbox && (
           <InputWrapper unitLabel={unitLabel}>
             <input
-              type="number"
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
               value={inputFieldValue}
               id={`${name}-textbox`}
               name={name}

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -124,7 +124,7 @@ export function Slider({
         {hasTextbox && (
           <InputWrapper unitLabel={unitLabel}>
             <input
-              type="number"
+              type="text"
               inputMode="numeric"
               pattern="[0-9]*"
               value={inputFieldValue}

--- a/libs/react/src/lib/slider/slider.tsx
+++ b/libs/react/src/lib/slider/slider.tsx
@@ -49,6 +49,7 @@ export function Slider({
   onChange,
   enableClamping = true,
   onClamp,
+  enterKeyHint,
 }: SliderProps) {
   const [background, setBackground] = React.useState<string>()
   const [sliderValue, setSliderValue] = React.useState<number | undefined>(
@@ -130,6 +131,7 @@ export function Slider({
               id={`${name}-textbox`}
               name={name}
               aria-labelledby={`${name}-label`}
+              enterKeyHint={enterKeyHint}
               className={errorMessage ? 'is-invalid' : ''}
               disabled={disabled}
               onChange={(e) => handleInputFieldChange(e.currentTarget.value)}

--- a/libs/react/src/types/props/index.ts
+++ b/libs/react/src/types/props/index.ts
@@ -33,6 +33,14 @@ export interface SliderProps {
   onChange?: (value: number) => void
   enableClamping?: boolean
   onClamp?: (value: number) => void
+  enterKeyHint?:
+    | 'enter'
+    | 'done'
+    | 'go'
+    | 'next'
+    | 'previous'
+    | 'search'
+    | 'send'
 
   /**
    * @deprecated Use `value` instead


### PR DESCRIPTION
The default keyboard for `<input type='number'>` on mobile devices is not always fitting for the Slider component. By default, iOS shows a layout with a row of numbers on top and then a collection of special characters below, and in this case the desired layout is the pure numerical keyboard.

This PR also adds forwarding of the [`enterkeyhint`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/enterkeyhint) attribute to the input field.

Closes #1047