### PR TITLE
fix(alert-ribbon): don't render empty header

### DIFF
--- a/apps/react-lib-dev/src/app/alert-ribbons.tsx
+++ b/apps/react-lib-dev/src/app/alert-ribbons.tsx
@@ -1,0 +1,50 @@
+import { AlertRibbon } from '@sebgroup/green-react'
+
+export const AlertRibbons = () => {
+  return (
+    <>
+      <div className="pt-5">
+        <AlertRibbon>
+          This one has a bunch of text and no header. Lorem ipsum dolor sit
+          amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+          exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+          dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est
+          laborum.
+        </AlertRibbon>
+      </div>
+      <div className="pt-5">
+        <AlertRibbon header="Alert!">
+          This one has a bunch of text and a header. Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+          labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
+          exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+          Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+          dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+          proident, sunt in culpa qui officia deserunt mollit anim id est
+          laborum.
+        </AlertRibbon>
+      </div>
+      <div className="pt-5">
+        <AlertRibbon
+          header={
+            <strong>
+              <i>Alert!</i>
+            </strong>
+          }
+        >
+          This one has a bunch of text and a custom header. Lorem ipsum dolor
+          sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+          incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+          quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+          commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+          velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+          occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+          mollit anim id est laborum.
+        </AlertRibbon>
+      </div>
+    </>
+  )
+}

--- a/apps/react-lib-dev/src/app/app.tsx
+++ b/apps/react-lib-dev/src/app/app.tsx
@@ -1,7 +1,6 @@
-import { Navbar, Tabs, Tab } from '@sebgroup/green-react'
-import { useState } from 'react'
-import { IValidator } from '@sebgroup/extract'
+import { Navbar, Tabs, Tab, AlertRibbon } from '@sebgroup/green-react'
 import { FormExample } from './form'
+import { AlertRibbons } from './alert-ribbons'
 
 export function App() {
   return (
@@ -17,8 +16,8 @@ export function App() {
                   <FormExample />
                 </div>
               </Tab>
-              <Tab title={'Other'}>
-                <div className="pt-5">Hello</div>
+              <Tab title={'Alert ribbons'}>
+                <AlertRibbons />
               </Tab>
             </Tabs>
           </div>

--- a/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
+++ b/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
@@ -61,15 +61,14 @@ export function AlertRibbon({
     }
   }
 
+  let renderedHeader: ReactNode = React.isValidElement(header) ? header : null;
+  renderedHeader = renderedHeader ?? <span className="header">{header}</span>;
+
   return (
     <div className={`alert-ribbon ${type}`} role={role} aria-live={ariaLive}>
       <i aria-hidden="true">{renderIcon()}</i>
       <div className="alert-ribbon__content">
-        {header && React.isValidElement(header) ? (
-          header
-        ) : (
-          <span className="header">{header}</span>
-        )}
+        {renderedHeader}
         <p>{children}</p>
       </div>
       {closeButton && (

--- a/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
+++ b/libs/react/src/lib/alert-ribbon/alert-ribbon.tsx
@@ -61,14 +61,23 @@ export function AlertRibbon({
     }
   }
 
-  let renderedHeader: ReactNode = React.isValidElement(header) ? header : null;
-  renderedHeader = renderedHeader ?? <span className="header">{header}</span>;
+  const renderHeader = () => {
+    if (!header) {
+      return null
+    }
+
+    return React.isValidElement(header) ? (
+      header
+    ) : (
+      <span className="header">{header}</span>
+    )
+  }
 
   return (
     <div className={`alert-ribbon ${type}`} role={role} aria-live={ariaLive}>
       <i aria-hidden="true">{renderIcon()}</i>
       <div className="alert-ribbon__content">
-        {renderedHeader}
+        {renderHeader()}
         <p>{children}</p>
       </div>
       {closeButton && (


### PR DESCRIPTION
Hi! Misael from team ToConsume on SEB.

Noticed that an extra margin was added to the alert ribbon when no header was passed, this due to an empty header div with style being added that had a margin right.

I propose to not render the header instead if it is empty. I have not been able to test this code so please try it out before merging it in.

Best regards Misael