### PR TITLE
feat(charts): add percentage formatting to tooltip

### DIFF
--- a/libs/charts/src/lib/billboard.spec.ts
+++ b/libs/charts/src/lib/billboard.spec.ts
@@ -263,6 +263,7 @@ describe('billboard', () => {
       const expected: Axis = {
         y: {
           show: false,
+          clipPath: false,
         },
       }
       expect(parsed.axis).toEqual(expected)
@@ -283,6 +284,7 @@ describe('billboard', () => {
       const expected: Axis = {
         x: {
           show: false,
+          clipPath: false,
         },
       }
       expect(parsed.axis).toEqual(expected)

--- a/libs/charts/src/lib/billboard.spec.ts
+++ b/libs/charts/src/lib/billboard.spec.ts
@@ -1,5 +1,5 @@
 import { ChartOptions, Chart, Axis } from 'billboard.js'
-import { ChartSettings, ChartProperties, Legend } from './types'
+import { ChartSettings, Legend } from './types'
 import { createOptions, createInfo } from './billboard'
 
 describe('billboard', () => {
@@ -307,6 +307,21 @@ describe('billboard', () => {
       }
       expect(parsed.axis).toEqual(expected)
     })
+    it('tooltip ratio format', () => {
+      const chartElement = '#foo'
+      const settings: ChartSettings = {
+        data: [],
+      }
+      const formatter = createOptions({
+        settings,
+        chartElement,
+      }).tooltip.format.value.bind({})
+      expect(formatter(undefined, 0)).toEqual('0%')
+      expect(formatter(undefined, 0.5)).toEqual('50%')
+      expect(formatter(undefined, 0.505)).toEqual('50.5%')
+      expect(formatter(undefined, 0.5055)).toEqual('50.55%')
+      expect(formatter(undefined, 0.50555)).toEqual('50.56%')
+    })
     it('overrides tooltip number format', () => {
       const chartElement = '#foo'
       const settings: ChartSettings = {
@@ -324,22 +339,22 @@ describe('billboard', () => {
       )
       expect(formattedNumber).toEqual('100 kr')
     })
-    it('does not override tooltip percentages', () => {
+    it('overrides tooltip percentages', () => {
       const chartElement = '#foo'
       const settings: ChartSettings = {
         data: [],
         style: {
-          tooltipNumberFormat: (value) => `${value} kr`,
+          tooltipNumberFormat: (value, ratio) => `${value}/${value / ratio}`,
         },
       }
       const parsed = createOptions({ settings, chartElement })
       const formattedNumber = parsed.tooltip.format.value.bind({})(
-        100,
+        10,
         0.1,
         undefined,
         undefined
       )
-      expect(formattedNumber).toEqual('10%')
+      expect(formattedNumber).toEqual('10/100')
     })
     it('add tick config if ticksCount is specified in style', () => {
       const chartElement = '#foo'

--- a/libs/charts/src/lib/billboard.ts
+++ b/libs/charts/src/lib/billboard.ts
@@ -164,6 +164,7 @@ export const createOptions = ({
             max: settings?.max,
             padding: settings?.padding,
             height: settings?.height,
+            ...(axis === 'y' || axis === 'x' ? { clipPath: false } : {}),
           },
         }),
         {

--- a/libs/charts/src/lib/billboard.ts
+++ b/libs/charts/src/lib/billboard.ts
@@ -61,6 +61,9 @@ export const createOptions = ({
   const defaultTooltipNumberFormat = (num: number) =>
     num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
 
+  const defaultTooltipPercentageFormat = (ratio: number) =>
+    `${Number((ratio * 100).toFixed(2))}%`
+
   const options: ChartOptions = {
     bindto: chartElement,
     data: {
@@ -71,13 +74,15 @@ export const createOptions = ({
     legend: { show: false },
     tooltip: {
       format: {
-        value: (value, ratio) => {
-          if (typeof ratio == 'number') return `${ratio * 100}%`
+        value: (value, ratio, id, index) => {
+          const formatOverride = settings?.style?.tooltipNumberFormat
+          if (typeof formatOverride === 'function') {
+            return formatOverride(value, ratio, id, index)
+          }
+          if (typeof ratio == 'number')
+            return defaultTooltipPercentageFormat(ratio)
           else {
-            const formatOverride = settings?.style?.tooltipNumberFormat
-            return typeof formatOverride == 'function'
-              ? formatOverride(value)
-              : defaultTooltipNumberFormat(value)
+            return defaultTooltipNumberFormat(value)
           }
         },
       },

--- a/libs/charts/src/lib/types.ts
+++ b/libs/charts/src/lib/types.ts
@@ -57,7 +57,12 @@ export interface ChartStyle extends Pick<ChartOptions, 'color'> {
   point?: {
     show?: boolean | 'focus'
   }
-  tooltipNumberFormat?: (value: number) => string
+  tooltipNumberFormat?: (
+    value: number,
+    ratio: number | undefined,
+    id: string,
+    index: number
+  ) => string
 }
 
 interface Tick {


### PR DESCRIPTION
Align the tooltipNumberFormat function with the format function in billboard.js. 
Also allow it to override the formatting for charts with ratio. 

The current percentage is not always correct (adds a lot of decimals even for numbers that javascript can divide correctly. Seems like the ratio value is calculated by the angle of the barchart pies rather than the actual values in the underlaying implementation - superwierd). Therefor also limiting the default to 2 decimals

Closes #687