### PR TITLE
feat: 🎸 override tooltip number formatting

### DIFF
--- a/libs/charts/src/lib/billboard.spec.ts
+++ b/libs/charts/src/lib/billboard.spec.ts
@@ -324,13 +324,27 @@ describe('billboard', () => {
       )
       expect(formattedNumber).toEqual('100 kr')
     })
-    it('does not override tooltip percentages', () => {
+    it('override tooltip percentages', () => {
       const chartElement = '#foo'
       const settings: ChartSettings = {
         data: [],
         style: {
           tooltipNumberFormat: (value) => `${value} kr`,
         },
+      }
+      const parsed = createOptions({ settings, chartElement })
+      const formattedNumber = parsed.tooltip.format.value.bind({})(
+        100,
+        0.1,
+        undefined,
+        undefined
+      )
+      expect(formattedNumber).toEqual('100 kr')
+    })
+    it('does not override tooltip percentages', () => {
+      const chartElement = '#foo'
+      const settings: ChartSettings = {
+        data: [],
       }
       const parsed = createOptions({ settings, chartElement })
       const formattedNumber = parsed.tooltip.format.value.bind({})(

--- a/libs/charts/src/lib/billboard.ts
+++ b/libs/charts/src/lib/billboard.ts
@@ -72,13 +72,19 @@ export const createOptions = ({
     tooltip: {
       format: {
         value: (value, ratio) => {
-          if (typeof ratio == 'number') return `${ratio * 100}%`
-          else {
-            const formatOverride = settings?.style?.tooltipNumberFormat
-            return typeof formatOverride == 'function'
-              ? formatOverride(value)
-              : defaultTooltipNumberFormat(value)
+          const formatOverride = settings?.style?.tooltipNumberFormat
+          if(formatOverride && typeof formatOverride == 'function') {
+            return formatOverride(value, ratio)
           }
+
+          if (typeof ratio == 'number') {
+            const percentageDecimals = settings?.style?.tooltipNumberPercentageDecimals ?? 2
+            const formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: percentageDecimals, style: "percent" })
+           
+            return formatter.format(ratio)
+          }
+
+          return defaultTooltipNumberFormat(value)
         },
       },
       contents: { template: tmplTooltip },
@@ -175,7 +181,7 @@ export const createOptions = ({
   let hasNegativeValue = false
   for (const dt of columns) {
     for (const val of dt) {
-      if (val < 0) {
+      if (val as number < 0) {
         hasNegativeValue = true
         break
       }

--- a/libs/charts/src/lib/types.ts
+++ b/libs/charts/src/lib/types.ts
@@ -57,7 +57,8 @@ export interface ChartStyle extends Pick<ChartOptions, 'color'> {
   point?: {
     show?: boolean | 'focus'
   }
-  tooltipNumberFormat?: (value: number) => string
+  tooltipNumberFormat?: (value: number, ratio?: number) => string
+  tooltipNumberPercentageDecimals?: number
 }
 
 interface Tick {

--- a/libs/react-charts/src/lib/chart.stories.tsx
+++ b/libs/react-charts/src/lib/chart.stories.tsx
@@ -55,7 +55,7 @@ Pie.args = {
       },
       {
         name: 'Utnyttjade',
-        values: [100],
+        values: [100.656544],
       },
     ],
     legend: 'right',


### PR DESCRIPTION
Currently it is not possible to override the formatting of tooltips on the charts even with the existing properties

BREAKING CHANGE: 🧨 None

✅ Closes: #687