### PR TITLE
fix(react/dropdown): simplify how the React wrapper handles state

### DIFF
--- a/libs/react/src/lib/dropdown/dropdown.stories.mdx
+++ b/libs/react/src/lib/dropdown/dropdown.stories.mdx
@@ -16,7 +16,7 @@ Dropdown Component
 <Story
   name="Dropdown"
   parameters={{
-    componentIds: ['component-dropdown']
+    componentIds: ['component-dropdown'],
   }}
   args={{
     loop: true,
@@ -36,7 +36,7 @@ Dropdown Component
     onChange: (value) => {
       console.log('OnChange', value)
     },
-    label: 'Dropdown label'
+    label: 'Dropdown label',
   }}
 >
   {Template.bind({})}
@@ -50,11 +50,11 @@ The dropdown options should be provided as an array of objects with label and va
 const options = [
   { label: 'Tacos', value: 'tacos' },
   { label: 'Pizza', value: 'pizza' },
-  { label: 'Sushi', value: 'sushi', selected: true },
+  { label: 'Sushi', value: 'sushi' },
 ]
 ```
 
-Provide an initial value by assigning the `value` property of the dropdown or declare the optional `selected?: boolean` to individual options as in the example above.
+Set the `value` prop to set the selected option/options. In multiple select mode, the value should be an array of values.
 
 By default, the dropdown will look for a label and value pair for the data. The following inputs can be set to alter the options if neccesary.
 
@@ -65,7 +65,7 @@ By default, the dropdown will look for a label and value pair for the data. The 
 
 ## Value Object
 
-Dropdown option values can even be an object, but not that it requires a `compareWith` function to uniquely identify each object. Eg:
+Dropdown option values can even be an object, but note that it requires a `compareWith` function to uniquely identify each object. Eg:
 
 <Canvas>
   <div style={{ height: '200px' }}>

--- a/libs/react/src/lib/dropdown/dropdown.stories.mdx
+++ b/libs/react/src/lib/dropdown/dropdown.stories.mdx
@@ -85,13 +85,9 @@ Dropdown option values can even be an object, but note that it requires a `compa
 
 Custom texts can be set using the texts input which takes an object with the following keys.
 
-| Text               | Description                                            | Default    |
-| :----------------- | :----------------------------------------------------- | :--------- |
-| selected           | Used when multiple items are selected e.g. 5 selected. | `selected` |
-| placeholder        | Text to display when no option is selected.            | `Select`   |
-| searchPlaceholder  | Text to display in Search box.                         | `Search`   |
-| close              | Text for close button displayed on mobiles.            | `Close`    |
-| optionsDescription | Text to describe options.                              | `Options`  |
+| Text        | Description                                 | Default  |
+| :---------- | :------------------------------------------ | :------- |
+| placeholder | Text to display when no option is selected. | `Select` |
 
 ## Multi select
 

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -11,7 +11,6 @@ export type DropdownPlacements = 'bottom-start' | 'top-start'
 export type OnChange<T = any> = (value: T) => void
 
 export type IndicatorType = 'success' | 'error' | 'info'
-
 export type ValidatorType = 'Required' | 'Email'
 
 export interface ValidatorRules {
@@ -82,6 +81,9 @@ export const Dropdown = ({
   id,
   informationLabel,
   label,
+  /**
+   * @deprecated
+   * */
   loop,
   multiSelect,
   onChange,
@@ -93,14 +95,9 @@ export const Dropdown = ({
   validator,
   value,
 }: DropdownProps) => {
-  const [selectedOption, setSelectedOption] = React.useState<
-    DropdownOption | undefined
-  >(options.find((o) => o.value === value))
-
   const handleOnChange = (e: any) => {
     if (e.detail?.value) {
-      setSelectedOption(options.find((o) => o[useValue] === e.detail.value))
-      onChange?.(e.detail?.value)
+      onChange?.(e.detail.value)
     }
   }
 
@@ -123,10 +120,10 @@ export const Dropdown = ({
         label={label}
         searchable={searchable}
         multiple={multiSelect}
-        value={selectedOption?.value}
         onchange={handleOnChange}
         invalid={validator?.indicator === 'error'}
         compareWith={compareWithAdapter}
+        value={value}
         searchFilter={searchFilterAdapter}
       >
         {informationLabel && <span slot="sub-label">{informationLabel}</span>}
@@ -135,11 +132,7 @@ export const Dropdown = ({
           {texts?.placeholder || 'Select'}
         </CoreOption>
         {options.map((option) => (
-          <CoreOption
-            key={option[useValue]}
-            value={option[useValue]}
-            selected={option.selected}
-          >
+          <CoreOption key={option[useValue]} value={option[useValue]}>
             {option[display]}
           </CoreOption>
         ))}

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -30,9 +30,7 @@ export interface DropdownArgs {
   id?: string
   informationLabel?: string
   label?: string
-  loop?: boolean
   multiSelect?: boolean
-  onTouched?: () => void
   options: DropdownOption[]
   searchFilter?: SearchFilter
   searchable?: boolean
@@ -42,12 +40,7 @@ export interface DropdownArgs {
   value?: any
 }
 export interface DropdownTexts {
-  select?: string
-  selected?: string
   placeholder?: string
-  searchPlaceholder?: string
-  close?: string
-  optionsDescription?: string
 }
 export interface DropdownOption {
   label?: string
@@ -81,10 +74,6 @@ export const Dropdown = ({
   id,
   informationLabel,
   label,
-  /**
-   * @deprecated
-   * */
-  loop,
   multiSelect,
   onChange,
   options,


### PR DESCRIPTION
The wrapper will now simply forward `value` to the underlying component, and value will correspond to the `[useValue]` field in the options object.

Closes #1090