### PR TITLE
fix(fonts): revert path change

### DIFF
--- a/libs/chlorophyll/scss/tokens/_shame.scss
+++ b/libs/chlorophyll/scss/tokens/_shame.scss
@@ -53,7 +53,7 @@ $font-family-sans-serif: 'SEBSansSerif', sans-serif, 'Helvetica Neue', Helvetica
   Arial !default;
 $root-font-size: 16px !default;
 $base-font-size: 1rem !default; // relative to root element font size (html)
-$font-path: '@sebgroup/fonts/fonts' !default;
+$font-path: '../fonts' !default;
 
 // z-index values for managing depth
 // based on what we have and use in bootstrap today


### PR DESCRIPTION
Turns out that this path is not relative to the project, but rather to the `.scss` file in the `@sebgroup/fonts` package. In other words, the previous default path was the correct one to use.