### PR TITLE
fix(dropdown): add missing label to close button

### DIFF
--- a/libs/core/src/generated/locales/sv.ts
+++ b/libs/core/src/generated/locales/sv.ts
@@ -11,6 +11,7 @@
     export const templates = {
       's58bfb494feb8eb02': str`${0} valda`,
 's5d929ff1619ac0c9': `Sök`,
+'s5e8250fb85d64c23': `Stäng`,
 'sd898d99fd9c13de6': `Sök i listan av val`,
     };
   

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit'
 import { property } from 'lit/decorators.js'
+import { msg } from '@lit/localize'
 import { createRef, ref, Ref } from 'lit/directives/ref.js'
 import { computePosition, autoUpdate, offset, flip } from '@floating-ui/dom'
 
@@ -76,7 +77,11 @@ export class GdsPopover extends LitElement {
     return html`<dialog ${ref(this.#dialogElementRef)}>
       <header>
         <h2>${this.label}</h2>
-        <button class="close" @click=${this.#handleCloseButton}>
+        <button
+          class="close"
+          @click=${this.#handleCloseButton}
+          aria-label="${msg('Close')}"
+        >
           <i></i>
         </button>
       </header>

--- a/libs/core/xliff/sv.xlf
+++ b/libs/core/xliff/sv.xlf
@@ -14,6 +14,10 @@
   <source>Search</source>
   <target>Sök</target>
 </trans-unit>
+<trans-unit id="s5e8250fb85d64c23">
+  <source>Close</source>
+  <target>Stäng</target>
+</trans-unit>
 </body>
 </file>
 </xliff>


### PR DESCRIPTION
This adds a missing `aria-label` to the close button in popovers. Only affects mobile viewport.