### PR TITLE
feat(react): groupFocus and className props

### DIFF
--- a/libs/react/src/lib/form/group/group.stories.mdx
+++ b/libs/react/src/lib/form/group/group.stories.mdx
@@ -17,6 +17,15 @@ Group inputs, buttons and other form elements together.
   </Group>
 </Canvas>
 
+## Static text in input field
+
+<Canvas>
+  <Group groupBorder groupFocus>
+    <TextInput placeholder="First input field" />
+    <span className="form-text">kr</span>
+  </Group>
+</Canvas>
+
 ## Inputs
 
 <Canvas>

--- a/libs/react/src/lib/form/group/group.tsx
+++ b/libs/react/src/lib/form/group/group.tsx
@@ -1,23 +1,31 @@
 import { ReactNode } from 'react'
+import classNames from 'classnames'
 
 /* eslint-disable-next-line */
 export interface GroupProps {
   children: ReactNode
   error?: Error | string
   groupBorder?: boolean
+  groupFocus?: boolean
   invalid?: boolean
   id?: string
+  className?: classNames.Argument
 }
 
 export function Group({
   id,
   children,
   error,
+  className,
   groupBorder = false,
+  groupFocus = false,
 }: GroupProps) {
-  const groupClassName = `group ${groupBorder ? 'group-border' : ''} ${
-    error ? 'is-invalid' : ''
-  }`
+  const groupClassName = classNames(
+    'group',
+    { 'group-border': groupBorder },
+    { 'group-focus': groupFocus },
+    className
+  )
   const errorMessage = error
     ? (error as Error).message || (error as string)
     : ''

--- a/libs/react/src/lib/form/group/group.tsx
+++ b/libs/react/src/lib/form/group/group.tsx
@@ -24,6 +24,7 @@ export function Group({
     'group',
     { 'group-border': groupBorder },
     { 'group-focus': groupFocus },
+    { 'is-invalid': error },
     className
   )
   const errorMessage = error


### PR DESCRIPTION
Form groups that should have focus on the whole group now requires the `group-focus` class. There was no way to set this in the React component.

Now you can do this, as well as pass your own classes to the group if needed.