### PR TITLE
fix(dropdown): hidden overflow with ellipsis by default

### DIFF
--- a/libs/angular/src/lib/dropdown/dropdown.component.html
+++ b/libs/angular/src/lib/dropdown/dropdown.component.html
@@ -42,7 +42,7 @@
 </div>
 
 <ng-template #defaultButton let-selected="option">
-  <span>{{ texts?.select }}</span>
+  <span class="trigger">{{ texts?.select }}</span>
 </ng-template>
 
 <ng-template #defaultOption let-option="option">

--- a/libs/angular/src/lib/dropdown/dropdown.component.scss
+++ b/libs/angular/src/lib/dropdown/dropdown.component.scss
@@ -1,0 +1,6 @@
+.trigger {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
+}

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -45,6 +45,7 @@ export interface DropdownOption {
 @Component({
   selector: 'ngg-dropdown',
   templateUrl: 'dropdown.component.html',
+  styleUrls: ['dropdown.component.scss'],
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/libs/core/src/components/dropdown/dropdown.trans.styles.scss
+++ b/libs/core/src/components/dropdown/dropdown.trans.styles.scss
@@ -16,6 +16,17 @@
   @include validation.add-feedback(tokens.$intent-danger-background);
 }
 
+::slotted([slot='trigger']) {
+  overflow: hidden;
+}
+
+slot[name='trigger'] > span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
+}
+
 .form-info {
   color: var(--text-primary-color);
   display: block;


### PR DESCRIPTION
When the content does not fit inside the space of the trigger, it should cut off with ellipsis instead of breaking to a new line. This was the default behaviour in the old version, so this PR fixes some incompatibilities caused by the upgrade.

This behavior can still be overridden with a custom trigger if a multi-line dropdown is required.