### PR TITLE
fix: 🐛 wizard next icon margin left

### DIFF
--- a/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
+++ b/libs/chlorophyll/scss/components/wizard/in-page/_mixins.scss
@@ -7,7 +7,7 @@
   margin-top: 0;
 
   button svg {
-    margin-right: .5rem;
+    margin-left: .5rem;
   }
 
   @include common.media-breakpoint-up('sm') {

--- a/libs/react/src/lib/in-page-wizard/inPageWizardStepCard.stories.mdx
+++ b/libs/react/src/lib/in-page-wizard/inPageWizardStepCard.stories.mdx
@@ -1,5 +1,9 @@
-import { Meta, Story, Canvas } from '@storybook/addon-docs'
+import { ArgsTable, Meta, Story, Canvas } from '@storybook/addon-docs'
 import { InPageWizardStepCard } from './inPageWizardStepCard'
+import { Label, List, Value } from '../list/valueList.tsx'
+import { Input } from '../form/input/input.tsx'
+import { TextArea } from '../form/textarea/textarea.tsx'
+import { Check } from '../icons'
 
 export const Template = ({ children, ...props }) => (
   <InPageWizardStepCard {...props}>{children}</InPageWizardStepCard>
@@ -12,88 +16,159 @@ export const Template = ({ children, ...props }) => (
 
 # InPageWizardStepCard
 
-An InPageWizardStepCard lets users add a step on a page.
+With InPageWizardStepCard it is possible for a user to quickly create wizard steps. Status for each step has to be provided so that it has the correct styles and renders correct.
 
-## An active step
+## Default
 
 <Canvas>
   <Story
     name="InPageWizardStepCard"
     args={{
-      stepText: 'Steg 1 av 3',
-      title: 'Nya lånet',
-      editBtnText: 'Ändra',
-      nextBtnText: 'Nästa',
+      children: 'Active step content',
+      nextBtnText: 'Next',
       stepStatus: 'IsActive',
-      onNextClick: () => {},
-      onEditClick: () => {},
-      children: <div>Content of Step 1</div>,
+      stepText: 'Active step text',
+      title: 'Active step title',
     }}
   >
     {Template.bind({})}
   </Story>
 </Canvas>
 
-## A not started step
+## Next button text
 
 <Canvas>
-  <Story
-    name="InPageWizardStepCard2"
-    args={{
-      stepText: 'Steg 2 av 3',
-      title: 'Sälja bostad',
-      editBtnText: 'Ändra',
-      nextBtnText: 'Nästa',
-      stepStatus: 'NotStarted',
-      onNextClick: () => {},
-      onEditClick: () => {},
-      children: <div>Content of Step 2</div>,
-    }}
+  <InPageWizardStepCard
+    editBtnText="Edit"
+    nextBtnText="My next button text"
+    stepStatus="IsActive"
+    stepText="Active step text"
+    title="Active step title"
   >
-    {Template.bind({})}
-  </Story>
+    Active step content
+  </InPageWizardStepCard>
 </Canvas>
 
-## A complete step
+## Next button icon
 
 <Canvas>
-  <Story
-    name="InPageWizardStepCard3"
-    args={{
-      stepText: 'Steg 3 av 3',
-      title: 'Hushåll och ekonomi',
-      editBtnText: 'Ändra',
-      nextBtnText: 'Nästa',
-      stepStatus: 'IsComplete',
-      onNextClick: () => {},
-      onEditClick: () => {},
-      children: <div>Content of Step 3</div>,
-    }}
+  <InPageWizardStepCard
+    editBtnText="Edit"
+    nextBtnText="Next"
+    nextBtnIcon={<Check />}
+    stepStatus="IsActive"
+    stepText="Active step text"
+    title="Active step title"
   >
-    {Template.bind({})}
-  </Story>
+    Active step content
+  </InPageWizardStepCard>
 </Canvas>
 
-## Description
+## Hidden footer
 
-With InPageWizardStepCard it is possible for a user to quickly create wizard steps. Status for each step has to be provided so that it has the correct styles and renders correct.
+<Canvas>
+  <InPageWizardStepCard
+    editBtnText="Edit"
+    nextBtnText="Next"
+    nextBtnIcon={<Check />}
+    stepStatus="IsActive"
+    stepText="Active step text"
+    title="Active step title"
+    hideFooter={true}
+  >
+    Active step content
+  </InPageWizardStepCard>
+</Canvas>
 
-## Props
+## Edit button text
 
-| Prop        | Type         | Description                                            |
-| :---------- | :----------- | :----------------------------------------------------- |
-| title       | `string`     | Title of the step.                                     |
-| stepText    | `string`     | Sub title for the title indicating 'Step X of Y'.      |
-| editBtnText | `string`     | Text on edit button.                                   |
-| nextBtnText | `string`     | Text on next button.                                   |
-| nextBtnIcon | `ReactNode`  | Icon for next button. Optional.                        |
-| stepStatus  | `string`     | Status for the step.                                   |
-| hideFooter  | `boolean`    | Force hiding of footer, regardless of state. Optional. |
-| children    | `string`     | Content for the step.                                  |
-| onNextClick | `() => void` | event for click on next button.                        |
-| onEditClick | `() => void` | event for click on edit button.                        |
-| dataTestid  | `string`     | testid for testing. Optional.                          |
+<Canvas>
+  <InPageWizardStepCard
+    editBtnText="My edit button text"
+    nextBtnText="Next"
+    stepStatus="IsComplete"
+    stepText="Completed step text"
+    title="Completed step title"
+  >
+    Completed step content
+  </InPageWizardStepCard>
+</Canvas>
 
-### WizardStepStatus
+## Status
 
-A step can only be in one of the following statuses: "NotStarted" | "IsActive" | "IsComplete"
+<Canvas>
+  <div>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Nästa"
+      stepStatus="IsComplete"
+      stepText="Step 1 of 3"
+      title="Completed step"
+    >
+      Content of Step 1
+    </InPageWizardStepCard>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Next"
+      stepStatus="IsActive"
+      stepText="Step 2 of 3"
+      title="Active step"
+    >
+      Content of Step 2
+    </InPageWizardStepCard>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Nästa"
+      stepStatus="NotStarted"
+      stepText="Step 3 of 3"
+      title="Not started step"
+    >
+      Content of Step 3
+    </InPageWizardStepCard>
+  </div>
+</Canvas>
+
+## Example
+
+<Canvas>
+  <div>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Nästa"
+      stepStatus="IsComplete"
+      stepText="Step 1 of 3"
+      title="Completed step"
+    >
+      <List>
+        <Label>Summary item 1</Label>
+        <Value>Summary value 1</Value>
+        <Label>Summary item 2</Label>
+        <Value>Summary value 2</Value>
+      </List>
+    </InPageWizardStepCard>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Next"
+      stepStatus="IsActive"
+      stepText="Step 2 of 3"
+      title="Active step"
+    >
+      <Input label="Input 1" />
+      <Input label="Input 2" />
+      <TextArea label="Text area" />
+    </InPageWizardStepCard>
+    <InPageWizardStepCard
+      editBtnText="Edit"
+      nextBtnText="Nästa"
+      stepStatus="NotStarted"
+      stepText="Step 3 of 3"
+      title="Not started step"
+    >
+      Content of Step 3
+    </InPageWizardStepCard>
+  </div>
+</Canvas>
+
+## Properties
+
+<ArgsTable of={InPageWizardStepCard} />

--- a/libs/react/src/lib/in-page-wizard/inPageWizardStepCard.tsx
+++ b/libs/react/src/lib/in-page-wizard/inPageWizardStepCard.tsx
@@ -1,73 +1,89 @@
-import { ReactNode } from 'react'
+import { PropsWithChildren, ReactNode } from 'react'
 import { Edit, Check } from '../icons'
+import classNames from 'classnames'
 
-export interface InPageWizardStepCardProps {
+export interface InPageWizardStepCardProps extends PropsWithChildren {
+  /** Sub title for the title indicating 'Step X of Y'. */
   stepText: string
+  /** Title of the step. */
   title: string
+  /** Text on edit button. */
   editBtnText?: string
-  nextBtnText: string
+  /** Text on next button. */
+  nextBtnText?: string
+  /** Icon for next button. */
   nextBtnIcon?: ReactNode
-  stepStatus: WizardStepStatus
+  /** Status for the step.*/
+  stepStatus: 'NotStarted' | 'IsActive' | 'IsComplete'
+  /** Force hiding of footer, regardless of state. */
   hideFooter?: boolean
-  children: React.ReactNode
-  onNextClick: () => void
+  /** Event for click on next button. */
+  onNextClick?: () => void
+  /** Event for click on edit button. */
   onEditClick?: () => void
+  /** Testid for testing. */
   dataTestid?: string
 }
 
-export type WizardStepStatus = 'NotStarted' | 'IsActive' | 'IsComplete'
+export const InPageWizardStepCard = ({
+  editBtnText = 'Ändra',
+  onNextClick,
+  stepStatus,
+  stepText,
+  title,
+  children,
+  dataTestid,
+  hideFooter = false,
+  nextBtnIcon,
+  nextBtnText = 'Nästa',
+  onEditClick,
+}: InPageWizardStepCardProps) => {
+  const sectionClassName = classNames('gds-in-page-wizard-step-card', 'card', {
+    active: stepStatus === 'IsActive',
+    completed: stepStatus === 'IsComplete',
+  })
 
-export const InPageWizardStepCard = (props: InPageWizardStepCardProps) => {
   return (
-    <section
-      className={`gds-in-page-wizard-step-card card ${
-        props.stepStatus === 'IsActive' ? 'active' : ''
-      } ${props.stepStatus === 'IsComplete' ? 'completed' : ''}`}
-      data-testid={props.dataTestid}
-    >
+    <section className={sectionClassName} data-testid={dataTestid}>
       <header className="gds-in-page-wizard-step-card__header">
         <div className="gds-in-page-wizard-step-card__header__icon">
           <Check />
         </div>
         <div className="gds-in-page-wizard-step-card__header__progress">
-          {props.stepText}
+          {stepText}
         </div>
         <div className="gds-in-page-wizard-step-card__header__title">
-          <h2 className="h4">{props.title}</h2>
+          <h2 className="h4">{title}</h2>
         </div>
 
-        {props.stepStatus === 'IsComplete' && (
+        {stepStatus === 'IsComplete' && (
           <div className="gds-in-page-wizard-step-card__header__edit">
-            <button className="secondary small" onClick={props.onEditClick}>
+            <button className="secondary small" onClick={onEditClick}>
               <Edit fill={'var(--color)'} height={16} width={16} />
-              {props.editBtnText}
+              {editBtnText}
             </button>
           </div>
         )}
       </header>
 
-      {(props.stepStatus === 'IsActive' ||
-        props.stepStatus === 'IsComplete') && (
-        <div className="gds-in-page-wizard-step-card__content">
-          {props.children}
-        </div>
+      {(stepStatus === 'IsActive' || stepStatus === 'IsComplete') && (
+        <div className="gds-in-page-wizard-step-card__content">{children}</div>
       )}
 
-      {props.stepStatus === 'IsActive' && !props.hideFooter && (
+      {stepStatus === 'IsActive' && !hideFooter && (
         <footer className="gds-in-page-wizard-step-card__footer">
-          <button className="primary" onClick={props.onNextClick}>
-            {props.nextBtnText}
-
-            {props.nextBtnIcon}
+          <button className="primary" onClick={onNextClick}>
+            {nextBtnText}
+            {nextBtnIcon}
           </button>
         </footer>
       )}
 
-      {props.stepStatus === 'IsComplete' && !props.hideFooter && (
+      {stepStatus === 'IsComplete' && !hideFooter && (
         <footer className="gds-in-page-wizard-step-card__footer__edit">
-          <button className="secondary" onClick={props.onEditClick}>
+          <button className="secondary" onClick={onEditClick}>
             <Edit fill={'var(--color)'} height={16} width={16} />
-            {props.editBtnText}
+            {editBtnText}
           </button>
         </footer>
       )}


### PR DESCRIPTION
Added margin left to the next button icon, added some documentation, used classNames for className rendering, added stories that show how multiple wizard steps look beside each other and story showing possible versions of the step.