### PR TITLE
fix: 🐛 use correct path for listbox-kb-nav-controller

### DIFF
--- a/libs/core/src/primitives/listbox/listbox.ts
+++ b/libs/core/src/primitives/listbox/listbox.ts
@@ -14,7 +14,7 @@ import {
 import {
   ListboxKbNavController,
   ListboxKbNavigation,
-} from 'src/controllers/listbox-kb-nav-controller'
+} from '../../controllers/listbox-kb-nav-controller'
 import { unwrap } from 'src/utils/helpers/unwrap-slots'
 
 /**

--- a/libs/core/src/primitives/menu/menu.ts
+++ b/libs/core/src/primitives/menu/menu.ts
@@ -7,7 +7,7 @@ import {
 import {
   ListboxKbNavController,
   ListboxKbNavigation,
-} from 'src/controllers/listbox-kb-nav-controller'
+} from '../../controllers/listbox-kb-nav-controller'
 import { unwrap } from 'src/utils/helpers/unwrap-slots'
 import { GdsMenuItem } from './menu-item'
 import { TransitionalStyles } from 'src/transitional-styles'


### PR DESCRIPTION
## Issue
When running [@sebgroup/green-angular@2.1.0](https://github.com/sebgroup/green/releases/tag/%40sebgroup%2Fgreen-angular%402.1.0), error appears "**Cannot find module 'src/controllers/listbox-kb-nav-controller' or its corresponding type declarations**"

## Solution
Use correct path for listbox-kb-nav-controller in listbox.ts and menu.ts

## Contributors
Team Comodo @ SEB