### PR TITLE
fix(core/context-menu): use the correct relative paths in imports

### DIFF
--- a/libs/core/src/primitives/listbox/listbox.ts
+++ b/libs/core/src/primitives/listbox/listbox.ts
@@ -1,4 +1,4 @@
-import { LitElement, unsafeCSS } from 'lit'
+import { LitElement } from 'lit'
 import { property } from 'lit/decorators.js'
 import { Ref, createRef, ref } from 'lit/directives/ref.js'
 import { TransitionalStyles } from '../../utils/helpers/transitional-styles'
@@ -14,8 +14,8 @@ import {
 import {
   ListboxKbNavController,
   ListboxKbNavigation,
-} from 'src/controllers/listbox-kb-nav-controller'
-import { unwrap } from 'src/utils/helpers/unwrap-slots'
+} from '../../controllers/listbox-kb-nav-controller'
+import { unwrap } from '../../utils/helpers/unwrap-slots'
 
 /**
  * @element gds-listbox

--- a/libs/core/src/primitives/menu/menu-item.ts
+++ b/libs/core/src/primitives/menu/menu-item.ts
@@ -1,10 +1,10 @@
 import { LitElement } from 'lit'
 import { Focusable } from '../../mixins/focusable'
-import { TransitionalStyles } from 'src/transitional-styles'
+import { TransitionalStyles } from '../../transitional-styles'
 import {
   gdsCustomElement,
   html,
-} from 'src/utils/helpers/custom-element-scoping'
+} from '../../utils/helpers/custom-element-scoping'
 
 /**
  * @element gds-menu-item

--- a/libs/core/src/primitives/menu/menu.ts
+++ b/libs/core/src/primitives/menu/menu.ts
@@ -3,14 +3,14 @@ import { Ref, createRef, ref } from 'lit/directives/ref.js'
 import {
   gdsCustomElement,
   html,
-} from 'src/utils/helpers/custom-element-scoping'
+} from '../../utils/helpers/custom-element-scoping'
 import {
   ListboxKbNavController,
   ListboxKbNavigation,
-} from 'src/controllers/listbox-kb-nav-controller'
-import { unwrap } from 'src/utils/helpers/unwrap-slots'
+} from '../../controllers/listbox-kb-nav-controller'
+import { unwrap } from '../../utils/helpers/unwrap-slots'
 import { GdsMenuItem } from './menu-item'
-import { TransitionalStyles } from 'src/transitional-styles'
+import { TransitionalStyles } from '../../transitional-styles'
 
 /**
  * @element gds-menu


### PR DESCRIPTION
The absolute paths works within the monorepo and in the tests, but fails in external use.