### PR TITLE
fix(core/popover): positioning regression in mobile views

### DIFF
--- a/apps/core-lib-dev/project.json
+++ b/apps/core-lib-dev/project.json
@@ -43,6 +43,7 @@
     },
     "serve": {
       "executor": "@nx/webpack:dev-server",
+      "inputs": ["core"],
       "options": {
         "buildTarget": "core-lib-dev:build",
         "port": 4210,

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -33,7 +33,14 @@ dialog {
   right: 0;
 
   @include common.media-breakpoint-down('sm') {
-    border-radius: 1rem;
+    border-radius: 0.5rem;
+    max-height: 80svh;
+
+    &.v-kb-visible {
+      height: 50svh;
+      inset-block-end: auto;
+      top: 1rem;
+    }
   }
 
   @include common.media-breakpoint-up('sm') {

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -11,10 +11,14 @@
 header {
   border-bottom: 1px solid var(--border-color);
   display: flex;
-  padding: 0.5rem 0.75rem;
+  padding: 0.25rem 0.75rem;
 
   @include common.media-breakpoint-up('sm') {
     display: none;
+  }
+
+  button.close {
+    margin: -0.25rem;
   }
 }
 
@@ -37,8 +41,8 @@ dialog {
     max-height: 80svh;
 
     &.v-kb-visible {
-      height: 50svh;
       inset-block-end: auto;
+      max-height: 50svh;
       top: 1rem;
     }
   }

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, unsafeCSS } from 'lit'
 import { property, state } from 'lit/decorators.js'
+import { classMap } from 'lit/directives/class-map.js'
 import { msg } from '@lit/localize'
 import { createRef, ref, Ref } from 'lit/directives/ref.js'
 import {
@@ -63,6 +64,10 @@ export class GdsPopover extends LitElement {
   @state()
   private _trigger: HTMLElement | undefined = undefined
 
+  // Whether the virtual keyboard is visible or not
+  @state()
+  private _isVirtKbVisible = false
+
   @watch('triggerRef')
   private _handleTriggerRefChanged() {
     this.triggerRef.then((el) => {
@@ -96,6 +101,20 @@ export class GdsPopover extends LitElement {
         e.stopImmediatePropagation()
       }
     })
+
+    // This is a hack to check if a virtual keyboard is visible or not.
+    // This should be removed in the future if/when the VirtualKeyboard API is suported on Safari.
+    this.addEventListener('focusin', (e: FocusEvent) => {
+      const t = e.target as HTMLElement
+      if (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA') {
+        this._isVirtKbVisible = true
+      } else {
+        this._isVirtKbVisible = false
+      }
+    })
+    this.addEventListener('blurin', (_) => {
+      this._isVirtKbVisible = false
+    })
   }
 
   disconnectedCallback(): void {
@@ -104,7 +123,10 @@ export class GdsPopover extends LitElement {
   }
 
   render() {
-    return html`<dialog ${ref(this.#dialogElementRef)}>
+    return html`<dialog
+      class="${classMap({ 'v-kb-visible': this._isVirtKbVisible })}"
+      ${ref(this.#dialogElementRef)}
+    >
       <header>
         <h2>${this.label}</h2>
         <button


### PR DESCRIPTION
This PR fixes incorrect positioning in the dropdown/context menu popover in mobile views.

It also adds a height adjustment when a virtual keyboard is present, to better accommodate dropdown with search.