### PR TITLE
fix: 🐛 update track background when min and max values change

### DIFF
--- a/libs/angular/src/lib/slider/slider.component.ts
+++ b/libs/angular/src/lib/slider/slider.component.ts
@@ -67,7 +67,7 @@ export class NggSliderComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (['min', 'max', 'value'].some((x: string) => changes.hasOwnProperty(x))) {
+    if (['min', 'max', 'value'].some((x: string) => Object.prototype.hasOwnProperty.call(changes, x))) {
       this.setTrackBackground()
     }
   }

--- a/libs/angular/src/lib/slider/slider.component.ts
+++ b/libs/angular/src/lib/slider/slider.component.ts
@@ -67,7 +67,7 @@ export class NggSliderComponent
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['value']) {
+    if (['min', 'max', 'value'].some((x: string) => changes.hasOwnProperty(x))) {
       this.setTrackBackground()
     }
   }


### PR DESCRIPTION
update slider track background when input min and max has changed, so it follows the "thumb" value:
![image](https://github.com/sebgroup/green/assets/82629695/947ee8ef-1e66-407a-af84-2cd28d8b885d)
