### PR TITLE
feat(core/dropdown): add `syncPopoverWidth` option

### DIFF
--- a/libs/core/src/components/dropdown/dropdown.stories.mdx
+++ b/libs/core/src/components/dropdown/dropdown.stories.mdx
@@ -110,3 +110,22 @@ the default trigger content will be overridden, and you will have to manage the 
     </gds-dropdown>
   </div>
 </Canvas>
+
+## Synced popover width
+
+Normally, the popover will never be narrower than the trigger, but may be wider if the option contents are wider.
+Optionally, the width of the popover can be locked to the width of the trigger by setting the `syncPopoverWidth` attribute.
+
+<Canvas>
+  <div style={{ height: '200px', dummy: registerTransitionalStyles() }}>
+    <gds-dropdown syncPopoverWidth style={{width: '200px'}}>
+      <gds-option value="1701-D-1">Enterprise 1701-D is a starship from the TNG series</gds-option>
+      <gds-option value="falcon-1">Millenium Falcon</gds-option>
+      <gds-option value="defiant-1">Defiant</gds-option>
+      <gds-option value="voyager-1">Voyager</gds-option>
+      <gds-option value="prometheus-1">Prometheus</gds-option>
+      <gds-option value="discovery-1">Discovery</gds-option>
+      <gds-option value="columbia-1">Columbia</gds-option>
+    </gds-dropdown>
+  </div>
+</Canvas>

--- a/libs/core/src/components/dropdown/dropdown.styles.ts
+++ b/libs/core/src/components/dropdown/dropdown.styles.ts
@@ -10,6 +10,7 @@ const style = css`
     color: white;
     padding: 0.7rem 2rem;
     margin: 0.5rem 0;
+    box-sizing: border-box;
   }
 `
 

--- a/libs/core/src/components/dropdown/dropdown.test.ts
+++ b/libs/core/src/components/dropdown/dropdown.test.ts
@@ -228,6 +228,31 @@ describe('<gds-dropdown>', () => {
     expect(popover?.clientWidth).to.be.greaterThanOrEqual(trigger.clientWidth)
   })
 
+  it('should be the same width as the trigger when `syncPopoverWidth`attribute is set', async () => {
+    const el = await fixture<GdsDropdown>(html`
+      <gds-dropdown syncPopoverWidth open>
+        <gds-option value="v1">Option 1</gds-option>
+        <gds-option value="v2">Option 2</gds-option>
+        <gds-option value="v3">Option 3</gds-option>
+        <gds-option
+          >This is a very long option text that will cause the popover to be
+          very wide</gds-option
+        >
+      </gds-dropdown>
+    `)
+
+    await el.updateComplete
+
+    const popover = el.shadowRoot
+      ?.querySelector<HTMLElement>(getScopedTagName('gds-popover'))
+      ?.shadowRoot?.querySelector<HTMLElement>('dialog')
+    const trigger = el.shadowRoot!.querySelector<HTMLElement>('button')!
+
+    await timeout(50)
+
+    expect(popover?.clientWidth).to.equal(trigger.clientWidth)
+  })
+
   it('should select complex value correctly with `compareWith` callback', async () => {
     const el = await fixture<GdsDropdown>(html`<gds-dropdown></gds-dropdown>`)
 

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -111,6 +111,17 @@ export class GdsDropdown<ValueT = any>
   searchFilter: (q: string, o: GdsOption) => boolean = (q, o) =>
     o.innerHTML.toLowerCase().includes(q.toLowerCase())
 
+  /**
+   * Whether the popover should sync its width to the trigger button. When this is
+   * set to `true`, the popover will always have the same width as the trigger button.
+   *
+   * By default, line-breaks will be applied to the option content if it is wider than
+   * the popover width. If you use this option, make sure to verify that your options
+   * are still readable and apply appropriate custom layout or truncation if neccecary.
+   */
+  @property({ type: Boolean })
+  syncPopoverWidth = false
+
   // Private members
   #optionElements: HTMLCollectionOf<GdsOption>
 
@@ -220,6 +231,8 @@ export class GdsDropdown<ValueT = any>
         .label=${this.label}
         .open=${this.open}
         .triggerRef=${this.elTriggerBtnAsync}
+        .calcMaxWidth=${(trigger: HTMLElement) =>
+          this.syncPopoverWidth ? `${trigger.offsetWidth}px` : `auto`}
         @gds-ui-state=${(e: CustomEvent) => (this.open = e.detail.open)}
       >
         ${when(

--- a/libs/core/src/primitives/popover/popover.styles.ts
+++ b/libs/core/src/primitives/popover/popover.styles.ts
@@ -1,10 +1,20 @@
 import { css } from 'lit'
 
 const style = css`
-  :host {
-    position: absolute;
-    background-color: white;
-    box-shadow: 0 1rem 1rem 1rem rgba(0, 0, 0, 0.1);
+  :host([open]) dialog {
+    opacity: 1;
+    transform: translate3d(0, 0, 0);
+    visibility: visible;
+  }
+
+  dialog {
+    inset: auto;
+    position: fixed;
+    overflow: hidden;
+    padding: 0px;
+    box-sizing: border-box;
+    border-width: 0;
+    right: 0;
   }
 `
 

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -3,6 +3,7 @@
 @use '../../../../chlorophyll/scss/common';
 
 :host([open]) dialog {
+  box-sizing: border-box;
   opacity: 1;
   transform: translate3d(0, 0, 0);
   visibility: visible;

--- a/libs/core/src/primitives/popover/popover.ts
+++ b/libs/core/src/primitives/popover/popover.ts
@@ -61,6 +61,13 @@ export class GdsPopover extends LitElement {
   @property()
   placement: Placement = 'bottom-start'
 
+  /**
+   * A callback that returns the maximum width of the popover.
+   * By default, the popover maxWidth will be set to `auto` and will grow as needed.
+   */
+  @property()
+  calcMaxWidth = (_referenceEl: HTMLElement) => `auto`
+
   @state()
   private _trigger: HTMLElement | undefined = undefined
 
@@ -237,6 +244,7 @@ export class GdsPopover extends LitElement {
           left: `${x}px`,
           top: `${y}px`,
           minWidth: `${referenceEl.offsetWidth}px`,
+          maxWidth: `${this.calcMaxWidth(referenceEl)}`,
         })
       )
     })


### PR DESCRIPTION
This options forces the popover to sync its with to the trigger button, even if some options are wider. When enabled, option text that is wider than the trigger will wrap by default.