### PR TITLE
fix(react/stepper): convert to pure controlled component

### DIFF
--- a/apps/react-lib-dev/src/app/form.tsx
+++ b/apps/react-lib-dev/src/app/form.tsx
@@ -79,6 +79,8 @@ export const FormExample = () => {
   const [value, setValue] = useState(0)
   const [ddValue, setDdValue] = useState()
 
+  const [stepperVal, setStepperVal] = useState(0)
+
   return (
     <>
       <h2>This is a form</h2>
@@ -178,7 +180,12 @@ export const FormExample = () => {
           validator={validator}
         />
 
-        <Stepper onChange={onStepperChange} />
+        <Stepper
+          onChange={(e) => setStepperVal(Number(e.target.value))}
+          value={stepperVal.toFixed(4)}
+          onIncrease={() => setStepperVal((v) => v + 0.0001)}
+          onDecrease={() => setStepperVal((v) => v - 0.0001)}
+        />
 
         <Slider
           hasTextbox={true}

--- a/libs/chlorophyll/scss/components/form/stepper/_mixins.scss
+++ b/libs/chlorophyll/scss/components/form/stepper/_mixins.scss
@@ -6,8 +6,6 @@ $_width: 4rem;
 $_font-size: 1.5rem;
 
 @mixin add-stepper() {
-  width: fit-content;
-  
   .button,
   button {
     width: 44px;

--- a/libs/extract/src/lib/stepper/stepper.ts
+++ b/libs/extract/src/lib/stepper/stepper.ts
@@ -1,8 +1,10 @@
+import { ChangeEventHandler } from 'react'
+
 export interface StepperArgs {
   id?: string
-  value?: number
+  value?: string | number
   min?: number
   max?: number
   step?: number
-  onChange?: (value: number) => void
+  onChange?: ChangeEventHandler<HTMLInputElement>
 }

--- a/libs/react/src/lib/stepper/stepper.spec.tsx
+++ b/libs/react/src/lib/stepper/stepper.spec.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Stepper, StepperProps } from './stepper'
+import { ChangeEvent } from 'react'
 
 jest.setTimeout(50000)
 
@@ -55,59 +56,34 @@ describe('Stepper', () => {
       }
     }
     it('goes up', async () => {
+      const onIncrease = jest.fn()
       const user = userEvent.setup()
-      const { buttonUp, input } = await renderComponent()
+      const { buttonUp } = await renderComponent({ onIncrease })
 
       await user.click(buttonUp)
-      await waitFor(() => expect(input.value).toEqual('1'))
+
+      expect(onIncrease).toHaveBeenCalledTimes(1)
     })
     it('goes down', async () => {
+      const onDecrease = jest.fn()
       const user = userEvent.setup()
-      const { buttonDown, input } = await renderComponent()
+      const { buttonDown } = await renderComponent({ onDecrease })
 
       await user.click(buttonDown)
-      await waitFor(() => expect(input.value).toEqual('-1'))
-    })
-    it('respects max', async () => {
-      const user = userEvent.setup()
-      const { buttonUp, input } = await renderComponent({ value: 8, max: 10 })
 
-      await user.click(buttonUp)
-      expect(input.value).toEqual('9')
-
-      await user.click(buttonUp)
-      expect(input.value).toEqual('10')
-
-      await user.click(buttonUp)
-      expect(input.value).toEqual('10')
-    })
-    it('respects min', async () => {
-      const user = userEvent.setup()
-      const { buttonDown, input } = await renderComponent({ value: 2, min: 0 })
-
-      await user.click(buttonDown)
-      expect(input.value).toEqual('1')
-
-      await user.click(buttonDown)
-      expect(input.value).toEqual('0')
-
-      await user.click(buttonDown)
-      expect(input.value).toEqual('0')
+      expect(onDecrease).toHaveBeenCalledTimes(1)
     })
     it('calls onChange', async () => {
       const onChange = jest.fn()
       const user = userEvent.setup()
-      const { buttonDown, buttonUp } = await renderComponent({
+      const { input } = await renderComponent({
         value: 0,
         onChange,
       })
 
-      await user.click(buttonUp)
-      expect(onChange).toHaveBeenCalledWith(1)
+      await user.type(input, '1')
 
-      await user.click(buttonDown)
-      await user.click(buttonDown)
-      expect(onChange).toHaveBeenCalledWith(-1)
+      expect(onChange).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/libs/react/src/lib/stepper/stepper.stories.mdx
+++ b/libs/react/src/lib/stepper/stepper.stories.mdx
@@ -3,7 +3,7 @@ import {Stepper, StepperProps} from './stepper'
 
 export const Template = (props) => <Stepper {...props} />
 
-<Meta title="Components/Stepper" component={Stepper}/>
+<Meta title="Components/Stepper" component={Stepper} />
 
 # Stepper
 
@@ -34,6 +34,23 @@ Create a basic Stepper that can be placed within a form by passing a label. The 
   />
 </Canvas>
 
+The Stepper currently only works in *controlled* mode, meaning that you app needs to handle all state.
+Here's a basic example:
+
+```jsx
+const [value, setValue] = useState(0)
+
+return (
+  <Stepper
+    label="Label"
+    value={value}
+    onChange={e => setValue(e.target.value)}
+    onIncrease={() => setValue(value + 1)}
+    onDecrease={() => setValue(value - 1)}
+  />
+)
+```
+
 ## Primitive stepper
 
 By omitting `label`, `description` and `statusMessage` props we don't wrap the component in a `form-group` and you can use it more unrestricted.
@@ -41,11 +58,6 @@ By omitting `label`, `description` and `statusMessage` props we don't wrap the c
 <Canvas>
   <Story
     name="Primitive Stepper"
-    args={{
-      min: 0,
-      max: 10,
-      step: 2,
-    }}
   />
 </Canvas>
 
@@ -60,21 +72,13 @@ We can then custom build our `form-group`as needed.
       <div>
         <div>
           <div className="form-info">Adults</div>
-          <Stepper
-            min={0}
-            max={10}
-            step={1}
-          />
+          <Stepper />
         </div>
       </div>
       <div>
         <div>
           <div className="form-info">Children under 18</div>
-          <Stepper
-            min={0}
-            max={10}
-            step={1}
-          />
+          <Stepper />
         </div>
       </div>
     </div>
@@ -89,9 +93,7 @@ We can then custom build our `form-group`as needed.
   <Story
     name="Stepper validation"
     args={{
-      min: 0,
-      max: 10,
-      step: 2,
+      value: 'Two',
       validator: {
         message: "Must be a number",
         indicator: "error"
@@ -100,20 +102,9 @@ We can then custom build our `form-group`as needed.
   />
 </Canvas>
 
-## Stepper props
+## Properties
 
-These props can be passed to the stepper component
+Note: Many of these are default HTMLInput props, and may not be relevant for this component.
 
-| Key         | Type                         |
-| :-------       | :------------------------ |
-| label?         | `string`                  |
-| description?   | `string`                  |
-| statusMessage? | `string`                  |
-| validator?     | `IValidator`              |
-| id?            | `string`                  |
-| value?         | `number`                  |
-| min?           | `number`                  |
-| max?           | `number`                  |
-| step?          | `number`                  |
-| onChange?      | `(value: number) => void` |
+<ArgsTable of={Stepper} />
 

--- a/libs/react/src/lib/stepper/stepper.tsx
+++ b/libs/react/src/lib/stepper/stepper.tsx
@@ -1,18 +1,24 @@
+import { IValidator, validateClassName, IndicatorType } from '@sebgroup/extract'
 import {
-  IValidator,
-  validateClassName,
-  IndicatorType,
-  StepperArgs,
-} from '@sebgroup/extract'
+  ChangeEventHandler,
+  DetailedHTMLProps,
+  InputHTMLAttributes,
+} from 'react'
 
-export interface StepperProps extends StepperArgs {
+export interface StepperProps
+  extends DetailedHTMLProps<
+    InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
+  id?: string
+  value?: string | number
+  onChange?: ChangeEventHandler<HTMLInputElement>
   label?: string
   description?: string
   statusMessage?: string
   validator?: IValidator
   onIncrease?: () => void
   onDecrease?: () => void
-  inputMode?: 'numeric' | 'decimal'
   testId?: string
 }
 
@@ -28,8 +34,8 @@ export function Stepper({
   onChange = () => undefined,
   onIncrease = () => undefined,
   onDecrease = () => undefined,
-  inputMode = 'numeric',
   testId,
+  ...props
 }: StepperProps) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowUp') {
@@ -54,13 +60,14 @@ export function Stepper({
       <input
         id={id}
         type="text"
-        inputMode={inputMode}
+        inputMode="numeric"
         pattern="[0-9]*"
         onChange={onChange}
         onFocus={({ target }) => target.select()}
         onKeyDown={handleKeyDown}
         placeholder="0"
         value={value}
+        {...props}
       />
       <button type="button" onClick={onIncrease}>
         +

--- a/libs/react/src/lib/stepper/stepper.tsx
+++ b/libs/react/src/lib/stepper/stepper.tsx
@@ -1,17 +1,19 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react'
 import {
   IValidator,
   validateClassName,
   IndicatorType,
   StepperArgs,
 } from '@sebgroup/extract'
-import { on } from 'events'
 
 export interface StepperProps extends StepperArgs {
   label?: string
   description?: string
   statusMessage?: string
   validator?: IValidator
+  onIncrease?: () => void
+  onDecrease?: () => void
+  inputMode?: 'numeric' | 'decimal'
+  testId?: string
 }
 
 // TODO: Should be named "Numeric input" instead of stepper?
@@ -24,73 +26,43 @@ export function Stepper({
   validator,
   value = 0,
   onChange = () => undefined,
-  min = Number.MIN_SAFE_INTEGER,
-  max = Number.MAX_SAFE_INTEGER,
-  step = 1,
+  onIncrease = () => undefined,
+  onDecrease = () => undefined,
+  inputMode = 'numeric',
+  testId,
 }: StepperProps) {
-  const [localValue, setLocalValue] = useState<number>(value)
-
-  const clamp = (v: number) => Math.max(min, Math.min(v, max))
-
-  const onChangeEvent = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
-      if (isNaN(e.target.valueAsNumber)) return
-      const value = clamp(e.target.valueAsNumber)
-      setLocalValue(value)
-      onChange(value)
-    },
-    [onChange]
-  )
-
-  useEffect(() => {
-    setLocalValue(value)
-  }, [value])
-
-  const down = () => {
-    if (localValue > min) {
-      const newValue = clamp(localValue - step)
-      setLocalValue(newValue)
-      onChange(newValue)
-    }
-  }
-
-  const up = () => {
-    if (localValue < max) {
-      const newValue = clamp(localValue + step)
-      setLocalValue(newValue)
-      onChange(newValue)
-    }
-  }
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowUp') {
       e.preventDefault()
-      up()
+      onIncrease()
     } else if (e.key === 'ArrowDown') {
       e.preventDefault()
-      down()
+      onDecrease()
     }
   }
 
   const PrimitiveStepper = (
     <div
+      data-testid={testId}
       className={`group group-border group-stepper ${
         validator && validateClassName(validator?.indicator as IndicatorType)
       }`}
     >
-      <button type="button" onClick={down}>
+      <button type="button" onClick={onDecrease}>
         -
       </button>
       <input
         id={id}
-        type="number"
-        onChange={onChangeEvent}
+        type="text"
+        inputMode={inputMode}
+        pattern="[0-9]*"
+        onChange={onChange}
         onFocus={({ target }) => target.select()}
         onKeyDown={handleKeyDown}
         placeholder="0"
-        value={localValue}
+        value={value}
       />
-      <button type="button" onClick={up}>
+      <button type="button" onClick={onIncrease}>
         +
       </button>
     </div>


### PR DESCRIPTION
This PR refactors the Stepper to work as a purely controlled component.

BREAKING CHANGES:
* `value` is now *only* owned by host application. This means `onIncrease` and `onDecrease` have to be implemented for the stepper to work.
* `onChange` now takes a `ChangeEvent<HTMLInputElement>` as param.
* These props have been removed:
  * `step`
  * `min`
  * `max` 