### PR TITLE
fix: 🐛 Change font weight for H5 and H6 

### DIFF
--- a/libs/chlorophyll/scss/tokens/_typography.scss
+++ b/libs/chlorophyll/scss/tokens/_typography.scss
@@ -173,19 +173,19 @@ $heading-04: (
 $heading-05: (
   desktop: (
     font-size: font-scale(2),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(3),
     letter-spacing: 0,
   ),
   tablet: (
     font-size: font-scale(2),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(3),
     letter-spacing: 0,
   ),
   mobile: (
     font-size: font-scale(2),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(3),
     letter-spacing: 0,
   )
@@ -194,19 +194,19 @@ $heading-05: (
 $heading-06: (
   desktop: (
     font-size: font-scale(1),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(2),
     letter-spacing: 0,
   ),
   tablet: (
     font-size: font-scale(1),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(2),
     letter-spacing: 0,
   ),
   mobile: (
     font-size: font-scale(1),
-    font-weight: font-weight('regular'),
+    font-weight: font-weight('medium'),
     line-height: line-height-scale(2),
     letter-spacing: 0,
   )

--- a/libs/chlorophyll/src/tokens/typography.ts
+++ b/libs/chlorophyll/src/tokens/typography.ts
@@ -70,12 +70,12 @@ export const typography: Record<Screen, Typography> = {
       lineHeight: '28px',
     },
     h5: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '16px',
       lineHeight: '24px',
     },
     h6: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '14px',
       lineHeight: '20px',
     },
@@ -117,12 +117,12 @@ export const typography: Record<Screen, Typography> = {
       lineHeight: '28px',
     },
     h5: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '16px',
       lineHeight: '24px',
     },
     h6: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '14px',
       lineHeight: '20px',
     },
@@ -164,12 +164,12 @@ export const typography: Record<Screen, Typography> = {
       lineHeight: '28px',
     },
     h5: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '16px',
       lineHeight: '24px',
     },
     h6: {
-      ...fonts.regular,
+      ...fonts.medium,
       size: '14px',
       lineHeight: '20px',
     },


### PR DESCRIPTION
Font weight for H5 and H6 should be medium according to Figma spec
Figma: [SEB Design System - Font Styles](https://www.figma.com/file/dX0HJ2MOaQyAOTziCD5fQ7/SEB-Design-System?node-id=20783%3A58371)

![image](https://github.com/sebgroup/green/assets/157685599/e20f0324-5889-4b7f-bf08-af31d00d4b40)


✅ Closes: #1172