### PR TITLE
fix: 🐛 update visible value when Dropdown/Datepicker formGroup changed programatically

### DIFF
--- a/.changeset/nasty-mice-study.md
+++ b/.changeset/nasty-mice-study.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+Update visible value when Dropdown/Datepicker formGroup changed programatically

--- a/libs/angular/src/lib/datepicker/datepicker.component.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.component.ts
@@ -117,6 +117,7 @@ export class NggDatepickerComponent
   writeValue(value: any): void {
     console.log('writeValue', value)
     this.value = value
+    this._cdr.detectChanges()
   }
 
   registerOnChange(fn: any): void {

--- a/libs/angular/src/lib/datepicker/datepicker.component.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.component.ts
@@ -86,7 +86,6 @@ export class NggDatepickerComponent
     if (newValue !== this._value) {
       this._value = newValue || undefined
     }
-    console.log('value', this._value)
   }
 
   @Input() id?: string = randomId()
@@ -115,7 +114,6 @@ export class NggDatepickerComponent
   }
 
   writeValue(value: any): void {
-    console.log('writeValue', value)
     this.value = value
     this._cdr.detectChanges()
   }

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -195,6 +195,7 @@ export class NggDropdownComponent implements ControlValueAccessor, OnInit {
 
   writeValue(value: any): void {
     this.value = value
+    this._cdr.detectChanges()
   }
 
   registerOnChange(fn: () => unknown): void {


### PR DESCRIPTION
fix for control.reset() not updating ui value, similar issue also likely with patch, setValue

BREAKING CHANGE:  -

✅ Closes: #1206


easier to reproduce in fresh form with formGroup similar to
```
  testForm = new FormGroup({
    country: new FormControl(),
    country2: new FormControl(),
  });

  options = [
    {
      label: 'Sweden',
      value: 'sweden',
    },
    {
      label: 'Denmark',
      value: 'denmark',
    },
    {
      label: 'Finland',
      value: 'Finland',
    },
  ];
  public test() {
    this.testForm.reset();
  }
```

```
<form *ngIf="testForm" [formGroup]="testForm">
  <div class="form-group">
    {{ testForm.controls.country.value | json }}
    <ngg-datepicker
      label="history-date-to"
      class="flex-grow"
      formControlName="country"
    />
    {{ testForm.controls.country2.value | json }}

    <ngg-dropdown label="Country" [options]="options" formControlName="country2"> </ngg-dropdown>
  </div>

  <button type="submit" (click)="test()">reset</button>
</form>
```