### PR TITLE
Datepicker input event when stepping in calendar

### DIFF
--- a/.changeset/five-buckets-sleep.md
+++ b/.changeset/five-buckets-sleep.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+Datepicker should emit `ìnput` event when focus is changed in the calendar

--- a/libs/core/src/components/datepicker/datepicker.test.ts
+++ b/libs/core/src/components/datepicker/datepicker.test.ts
@@ -466,6 +466,64 @@ describe('<gds-datepicker>', () => {
       await expect(spinners[1].value.toString()).to.equal('mm')
       await expect(spinners[2].value.toString()).to.equal('dd')
     })
+
+    it('should emit input event when navigating with arrow keys in calendar popover', async () => {
+      const el = await fixture<GdsDatepicker>(
+        html`<gds-datepicker value="2024-01-01"></gds-datepicker>`
+      )
+      const button = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[aria-controls="calendar-popover"]'
+      )!
+      const popover =
+        el.shadowRoot!.querySelector<GdsPopover>('#calendar-popover')!
+
+      const inputHandler = sinon.fake()
+      el.addEventListener('input', inputHandler)
+
+      await clickOnElement(button)
+      await conditionToBeTrue(() => popover.open)
+
+      await sendKeys({
+        press: 'ArrowRight',
+      })
+
+      await timeout(0)
+      await el.updateComplete
+
+      await expect(inputHandler.calledOnce).to.be.true
+    })
+
+    it('should reset to initial value when pressing escape in the popover', async () => {
+      const el = await fixture<GdsDatepicker>(
+        html`<gds-datepicker value="2024-01-01"></gds-datepicker>`
+      )
+
+      const button = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[aria-controls="calendar-popover"]'
+      )!
+      const popover =
+        el.shadowRoot!.querySelector<GdsPopover>('#calendar-popover')!
+
+      await clickOnElement(button)
+      await conditionToBeTrue(() => popover.open)
+
+      await sendKeys({
+        press: 'ArrowRight',
+      })
+
+      await el.updateComplete
+
+      await sendKeys({
+        press: 'Escape',
+      })
+
+      await timeout(0)
+      await el.updateComplete
+
+      await expect(onlyDate(el.value!)).to.equal(
+        onlyDate(new Date('2024-01-01'))
+      )
+    })
   })
 
   describe('Accessibility', () => {

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -424,6 +424,14 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
     )
   }
 
+  #dispatchInputEvent() {
+    this.dispatchEvent(
+      new CustomEvent('input', {
+        detail: { value: this.value },
+      })
+    )
+  }
+
   #handleClipboardCopy = (e: ClipboardEvent) => {
     e.preventDefault()
     e.clipboardData?.setData('text/plain', this.displayValue)
@@ -484,15 +492,20 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
     this._focusedYear = (await this._elCalendar).focusedYear
     this.value = (await this._elCalendar).focusedDate
     this.requestUpdate()
-    this.#dispatchChangeEvent()
+    this.#dispatchInputEvent()
   }
 
-  #handlePopoverStateChange = (e: CustomEvent) => {
+  #handlePopoverStateChange = async (e: CustomEvent) => {
     if (e.target !== e.currentTarget) return
     this.open = e.detail.open
+
+    if (e.detail.reason === 'close') {
+      this.value = (await this._elCalendar).focusedDate
+      this.#dispatchChangeEvent()
+    }
+
     if (e.detail.reason === 'cancel') {
       this.value = this.#valueOnOpen
-      this.#dispatchChangeEvent()
     }
   }
 


### PR DESCRIPTION
Currently, stepping in the calendar changes the value and emits `change` events. This PR changes this behaviour so that it instead emits `input` events, until the value is committed by clicking on a date, pressing enter or by clicking outside to close. The `change` event is only emitted when the value is considered committed. Esc aborts by reverting to the value the Datepicker had when the calendar was opened.

This change is made to closer match the native `<input type="date">`