### PR TITLE
Datepicker: Add support for disabling dates

### DIFF
--- a/.changeset/honest-bags-doubt.md
+++ b/.changeset/honest-bags-doubt.md
@@ -1,0 +1,10 @@
+---
+'@sebgroup/green-angular': minor
+'@sebgroup/green-react': minor
+'@sebgroup/green-core': minor
+---
+
+**Datepicker:** Added support for disabling dates
+
+- `disabled-weekends` will disable all weekend days in the calendar view
+- `disabled-dates` allows to specify an array of dates that should be disabled in the calendar view

--- a/apps/react-lib-dev/src/app/form.tsx
+++ b/apps/react-lib-dev/src/app/form.tsx
@@ -100,7 +100,12 @@ export const FormExample = () => {
             onChange={setDdValue}
             searchable={true}
           />
-          <Datepicker value={date} onChange={setDate} />
+          <Datepicker
+            value={date}
+            onChange={setDate}
+            disabledWeekends={true}
+            disabledDates={[new Date(2024, 2, 13)]}
+          />
         </div>
 
         <div>

--- a/libs/angular/.storybook/preview.js
+++ b/libs/angular/.storybook/preview.js
@@ -10,6 +10,6 @@ export const parameters = {
   ...baseParameters,
   docs: {
     ...baseParameters.docs,
-    iframeHeight: 300,
+    iframeHeight: 400,
   },
 }

--- a/libs/angular/src/lib/datepicker/datepicker.component.html
+++ b/libs/angular/src/lib/datepicker/datepicker.component.html
@@ -12,6 +12,8 @@
     [dateformat]="dateFormat"
     [size]="size"
     [hideLabel]="hideLabel"
+    [disabledWeekends]="disabledWeekends"
+    [disabledDates]="disabledDates"
   >
     <span slot="message">
       <ng-content select="[data-form-info]"></ng-content>

--- a/libs/angular/src/lib/datepicker/datepicker.component.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.component.ts
@@ -64,6 +64,8 @@ export class NggDatepickerComponent
 {
   @Input() size?: 'small' | 'medium'
   @Input() hideLabel?: boolean
+  @Input() disabledWeekends?: boolean
+  @Input() disabledDates?: Date[]
 
   @Input()
   get options(): DatepickerOptions {

--- a/libs/angular/src/lib/datepicker/datepicker.stories.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.stories.ts
@@ -55,6 +55,8 @@ Simple.args = {
 export const CustomOptions = Template.bind({})
 CustomOptions.args = {
   label: 'Birthday',
+  disabledWeekends: true,
+  disabledDates: [new Date(2024, 1, 6), new Date(2023, 12, 4)],
   options: {
     minDate: startOfYear(subYears(new Date(), 100)),
     maxDate: new Date(),

--- a/libs/angular/src/lib/datepicker/documentation.mdx
+++ b/libs/angular/src/lib/datepicker/documentation.mdx
@@ -1,4 +1,4 @@
-import {Story} from '@storybook/addon-docs'
+import { Story } from '@storybook/addon-docs'
 
 # Datepicker
 
@@ -15,17 +15,14 @@ import { NggDatepickerModule } from '@sebgroup/green-angular'
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [
-    BrowserModule,
-    ReactiveFormsModule,
-    NggDatepickerModule
-  ],
+  imports: [BrowserModule, ReactiveFormsModule, NggDatepickerModule],
   exports: [],
 })
 export class AppModule {}
 ```
 
 ## Datepicker
+
 NggDatepickerComponent is a form control for picking dates.
 
 It supports 2-way binding to the value property without the need for Angular forms,
@@ -34,16 +31,18 @@ and supports all the form directives from the core FormsModule (NgModel) and Rea
 <Story id="components-datepicker--simple" />
 
 ## Reactive forms
+
 We recommend using <a href="https://angular.io/guide/reactive-forms" target="_blank">Reactive forms</a> in Angular together with the <a href="https://angular.io/api/forms/FormBuilder" target="_blank">From builder</a> especially
 if you're dealing with complex or dynamic forms.
 
 ```html
 <form [formGroup]="reactiveForm">
-    <ngg-datepicker formControlName="date" label="Date"></ngg-datepicker>
+  <ngg-datepicker formControlName="date" label="Date"></ngg-datepicker>
 </form>
 ```
 
 ## Template-driven forms
+
 Another approach is to use <a href="https://angular.io/guide/forms" target="_blank">Template-driven forms</a> and bind value using `ngModel`.
 
 ```html
@@ -53,38 +52,48 @@ Another approach is to use <a href="https://angular.io/guide/forms" target="_bla
 ```
 
 ## 2-way binding without forms
+
 If you just need a simple select without any form, validation etc. it's possible to bind the dropdown directly to a value.
 
-
 ```html
-  <ngg-datepicker [(value)]="date" label="Date"></ngg-datepicker>
+<ngg-datepicker [(value)]="date" label="Date"></ngg-datepicker>
 ```
-
 
 ## Inputs
-|Input (attribute)|Description|Default|
-|:--------|:----------|:------|
-|options|`DatepickerOptions` for datepicker see more info below. | n/a |
-|label|Text to use as label for datepicker input.| n/a |
-|id|Id applied to datepicker elements.|`random id`|
-|isValid|Mark datepicker as invalid/valid.| `null` |
-|size|Size of the datepicker input. Possible values are `small` and `medium`.| `medium` |
-|hideLabel|Hide the label for the datepicker input.| `false` |
+
+| Input (attribute) | Description                                                             | Default     |
+| :---------------- | :---------------------------------------------------------------------- | :---------- |
+| options           | `DatepickerOptions` for datepicker see more info below.                 | n/a         |
+| label             | Text to use as label for datepicker input.                              | n/a         |
+| id                | Id applied to datepicker elements.                                      | `random id` |
+| isValid           | Mark datepicker as invalid/valid.                                       | `null`      |
+| size              | Size of the datepicker input. Possible values are `small` and `medium`. | `medium`    |
+| hideLabel         | Hide the label for the datepicker input.                                | `false`     |
+| disabledDates     | Array of dates to disable                                               | `[]`        |
+| disabledWeekends  | Disable all weekends in the calendar view                               | `false`     |
 
 ## DatepickerOptions
-|Option|Description|Default|
-|:--------|:----------|:------|
-|showWeeks|Show week numbers.| `false` |
-|minDate|Min date for datepicker, dates before this date are disabled.| `startOfYear(subYears(new Date(), 5))` |
-|maxDate|Max date for datepicker, dates after this date are disabled.| `endOfYear(addYears(new Date(), 5))` |
-|dateFormat|Date format for the input field. Use letters `d`, `m`, `y` to specify the order of day, month, year, separated by a delimiter. For example `y-m-d` or `d/m/y` | `y-m-d` |
 
+| Option     | Description                                                                                                                                                   | Default                                |
+| :--------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------- |
+| showWeeks  | Show week numbers.                                                                                                                                            | `false`                                |
+| minDate    | Min date for datepicker, dates before this date are disabled.                                                                                                 | `startOfYear(subYears(new Date(), 5))` |
+| maxDate    | Max date for datepicker, dates after this date are disabled.                                                                                                  | `endOfYear(addYears(new Date(), 5))`   |
+| dateFormat | Date format for the input field. Use letters `d`, `m`, `y` to specify the order of day, month, year, separated by a delimiter. For example `y-m-d` or `d/m/y` | `y-m-d`                                |
 
 ```html
-  <ngg-datepicker [(value)]="date" label="Birthday" options="{showWeeks: true, minDate: startOfYear(subYears(new Date(), 100)), maxDate: new Date(), dateFormat: 'd/m/y' }"></ngg-datepicker>
+<ngg-datepicker
+  [(value)]="date"
+  label="Birthday"
+  [disabledWeekends]="true"
+  [disabledDates]="[new Date(2024, 1, 6), new Date(2023, 12, 4)]"
+  options="{showWeeks: true, minDate: startOfYear(subYears(new Date(), 100)), maxDate: new Date(), dateFormat: 'd/m/y' }"
+></ngg-datepicker>
 ```
 
-<Story id="components-datepicker--custom-options" />
+<Canvas>
+  <Story id="components-datepicker--custom-options" />
+</Canvas>
 
 ## Example usage in reactive form
 
@@ -92,23 +101,23 @@ Below is an example of how the component can be used with reactive forms and val
 
 ```ts
 validationForm = this._fb.group({
-    date: [
-      null,
-      [
-        Validators.required,
-        dateValidator({
-          min: this.options.minDate,
-          max: this.options.maxDate,
-        }),
-      ],
+  date: [
+    null,
+    [
+      Validators.required,
+      dateValidator({
+        min: this.options.minDate,
+        max: this.options.maxDate,
+      }),
     ],
-  })
+  ],
+})
 ```
-
 
 <Story id="components-datepicker--form" />
 
 ### Markup
+
 ```html
 <form [formGroup]="validationForm" #ngForm="ngForm" (submit)="save()">
   <ng-container *ngIf="validationForm.get('date') as date">
@@ -118,7 +127,9 @@ validationForm = this._fb.group({
       [isValid]="ngForm.submitted ? date.valid : null"
     >
       <!-- Hint text when not submitted -->
-      <ng-container data-form-info *ngIf="!ngForm['submitted']">Select date</ng-container>
+      <ng-container data-form-info *ngIf="!ngForm['submitted']"
+        >Select date</ng-container
+      >
       <ng-container data-form-info *ngIf="ngForm['submitted']">
         <!-- Text when form control contains one or more errors -->
         <ng-container *ngIf="date.errors as errors">
@@ -129,22 +140,24 @@ validationForm = this._fb.group({
           >
           <ng-container
             *ngIf="errors['validDate'] && errors['validDate']['minDate']"
-            >Enter date after
-            {{
-              errors['validDate']['minDate'] | date: 'shortDate'
-            }}</ng-container>
+            >Enter date after {{ errors['validDate']['minDate'] | date:
+            'shortDate' }}</ng-container
+          >
           <ng-container
             *ngIf="errors['validDate'] && errors['validDate']['maxDate']"
-            >Enter date before
-            {{
-              errors['validDate']['maxDate'] | date: 'shortDate'
-            }}</ng-container>
+            >Enter date before {{ errors['validDate']['maxDate'] | date:
+            'shortDate' }}</ng-container
+          >
         </ng-container>
       </ng-container>
     </ngg-datepicker>
   </ng-container>
   <button type="reset" (click)="ngForm.reset()">Reset</button>
-  <button class="ms-3" type="submit" [disabled]="ngForm.submitted && validationForm.invalid">
+  <button
+    class="ms-3"
+    type="submit"
+    [disabled]="ngForm.submitted && validationForm.invalid"
+  >
     Save
   </button>
 </form>

--- a/libs/core/src/components/datepicker/datepicker.stories.mdx
+++ b/libs/core/src/components/datepicker/datepicker.stories.mdx
@@ -18,10 +18,13 @@ by typing a number.
 Clicking the calendar icon opens a popover with a calendar view where a date can be chosen.
 
 <Canvas>
-<div style={{ dummy: registerTransitionalStyles() }}>
-<gds-datepicker label="Label" onchange="document.getElementById('chosen-date').innerHTML = this.value?.toISOString() || 'None'"></gds-datepicker>
-Chosen date: <span id="chosen-date">None</span>
-</div>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-datepicker
+      label="Label"
+      onchange="document.getElementById('chosen-date').innerHTML = this.value?.toISOString() || 'None'"
+    ></gds-datepicker>
+    Chosen date: <span id="chosen-date">None</span>
+  </div>
 </Canvas>
 
 ## Basic usage
@@ -35,12 +38,16 @@ input. The `message` slot is used to display instructions and/or validation erro
 When the value is changed by a user, a `change` event is fired.
 
 <Canvas>
-<div style={{ dummy: registerTransitionalStyles() }}>
-<gds-datepicker label="Using slots" onchange="console.log(this.value)">
-  <span slot="sub-label">A sub-label can be added as additional description</span>
-  <span slot="message">Instructive message. Will turn red if there is a validation error</span>
-</gds-datepicker>
-</div>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-datepicker label="Using slots" onchange="console.log(this.value)">
+      <span slot="sub-label">
+        A sub-label can be added as additional description
+      </span>
+      <span slot="message">
+        Instructive message. Will turn red if there is a validation error
+      </span>
+    </gds-datepicker>
+  </div>
 </Canvas>
 
 ## Week numbers
@@ -48,12 +55,12 @@ When the value is changed by a user, a `change` event is fired.
 Use the `show-week-numbers` attribute to show a week numbers column in the calendar view.
 
 <Canvas>
-<div style={{ dummy: registerTransitionalStyles() }}>
-<gds-datepicker
-  label="With week numbers"
-  show-week-numbers>
-</gds-datepicker>
-</div>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-datepicker
+      label="With week numbers"
+      show-week-numbers
+    ></gds-datepicker>
+  </div>
 </Canvas>
 
 ## Min and max dates
@@ -61,13 +68,32 @@ Use the `show-week-numbers` attribute to show a week numbers column in the calen
 Use the `min` and `max` attributes to set the minimum and maximum dates that can be selected. Dates outside of this range will be disabled in the calendar view.
 
 <Canvas>
-<div style={{ dummy: registerTransitionalStyles() }}>
-<gds-datepicker
-  label="Using min and max dates"
-  min="2022-11-11"
-  max="2024-02-20">
-</gds-datepicker>
-</div>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-datepicker
+      label="Using min and max dates"
+      min="2022-11-11"
+      max="2024-02-20"
+    ></gds-datepicker>
+  </div>
+</Canvas>
+
+## Disabled dates
+
+Set the `disable-weekends` attribute to disable weekends (saturdays and sundays) in the calendar view.
+
+Additionally, `disabled-dates` can be used to disable specific dates.
+
+- When set via the `disabled-dates` attribute, this should be a comma-separated list of date strings that can be parsed by the Javscript `Date()` constructor.
+- When set via the `disabledDates` property, it should be an array of Javascript `Date` objects.
+
+<Canvas>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-datepicker
+      label="Disabled weekends"
+      disabled-weekends
+      disabled-dates="2024-03-08, 2024-04-12, 2024-03-18, 2024-03-19"
+    ></gds-datepicker>
+  </div>
 </Canvas>
 
 ## Input field size
@@ -77,11 +103,11 @@ The date picker has two sizes: `small` and `medium`. The default size is `medium
 Optionally, the label can be hidden by using the `hide-label` attribute.
 
 <Canvas>
-<div style={{ dummy: registerTransitionalStyles(), display: 'inline-block' }}>
-<gds-datepicker
-  label="A small datepicker"
-  hide-label
-  size="small">
-</gds-datepicker>
-</div>
+  <div style={{ dummy: registerTransitionalStyles(), display: 'inline-block' }}>
+    <gds-datepicker
+      label="A small datepicker"
+      hide-label
+      size="small"
+    ></gds-datepicker>
+  </div>
 </Canvas>

--- a/libs/core/src/components/datepicker/datepicker.test.ts
+++ b/libs/core/src/components/datepicker/datepicker.test.ts
@@ -176,6 +176,38 @@ describe('<gds-datepicker>', () => {
 
       await expect(focusedDate).to.be.undefined
     })
+
+    it('Setting `disabled-weekends` should disable weekends', async () => {
+      const el = await fixture<GdsDatepicker>(
+        html`<gds-datepicker
+          value="2024-01-10"
+          disabled-weekends
+          open
+        ></gds-datepicker>`
+      )
+
+      await el.updateComplete
+
+      const disabledDatecell = await el.test_getDateCell(13)
+
+      await expect(disabledDatecell).to.have.attribute('disabled')
+    })
+
+    it('Setting `disabled-dates` should disable dates', async () => {
+      const el = await fixture<GdsDatepicker>(
+        html`<gds-datepicker
+          value="2024-01-10"
+          disabled-dates="2024-01-13"
+          open
+        ></gds-datepicker>`
+      )
+
+      await el.updateComplete
+
+      const disabledDatecell = await el.test_getDateCell(13)
+
+      await expect(disabledDatecell).to.have.attribute('disabled')
+    })
   })
 
   describe('Interactions', () => {

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -46,6 +46,15 @@ const dateConverter = {
   },
 }
 
+const dateArrayConverter = {
+  fromAttribute(value: string) {
+    return value.split(',').map((d) => new Date(d.trim()))
+  },
+  toAttribute(value: Date[]) {
+    return JSON.stringify(value.map((d) => d.toISOString()))
+  },
+}
+
 /**
  * @element gds-datepicker
  * A form control that allows the user to select a date.
@@ -132,6 +141,18 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
   set dateformat(dateformat: string) {
     this._dateFormatLayout = this.#parseDateFormat(dateformat)
   }
+
+  /**
+   * Whether to disable weekends in the calendar.
+   */
+  @property({ type: Boolean, attribute: 'disabled-weekends' })
+  disabledWeekends = false
+
+  /**
+   * An array of dates that should be disabled in the calendar.
+   */
+  @property({ converter: dateArrayConverter, attribute: 'disabled-dates' })
+  disabledDates?: Date[]
 
   /**
    * Get the currently focused date in the calendar popover. If no date is focused, or the calendar popover
@@ -334,6 +355,8 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
           .min=${this.min}
           .max=${this.max}
           .showWeekNumbers=${this.showWeekNumbers}
+          .disabledWeekends=${this.disabledWeekends}
+          .disabledDates=${this.disabledDates}
         ></gds-calendar>
 
         <div class="footer">

--- a/libs/core/src/primitives/calendar/calendar.ts
+++ b/libs/core/src/primitives/calendar/calendar.ts
@@ -62,6 +62,18 @@ export class GdsCalendar extends GdsElement {
   focusedDate = new Date()
 
   /**
+   * Whether to disable weekends or not.
+   */
+  @property({ type: Boolean, attribute: 'disabled-weekends' })
+  disabledWeekends = false
+
+  /**
+   * An array of dates that should be disabled in the calendar.
+   */
+  @property({ type: Array<Date>, attribute: 'disabled-dates' })
+  disabledDates?: Date[]
+
+  /**
    * The month that is currently focused.
    */
   @property({ type: Number })
@@ -147,14 +159,23 @@ export class GdsCalendar extends GdsElement {
                         </td>`
                     )}
                     ${week.days.map((day) => {
-                      const isDisabled =
+                      const isOutsideCurrentMonth =
                         !isSameMonth(this.focusedDate, day) ||
                         day < this.min ||
                         day > this.max
+
+                      const isWeekend = day.getDay() === 0 || day.getDay() === 6
+
+                      const isDisabled =
+                        isOutsideCurrentMonth ||
+                        (this.disabledWeekends && isWeekend) ||
+                        (this.disabledDates &&
+                          this.disabledDates.some((d) => isSameDay(d, day)))
+
                       return html`
                         <td
                           class="${classMap({
-                            disabled: isDisabled,
+                            disabled: Boolean(isDisabled),
                             today: isSameDay(currentDate, day),
                           })}"
                           ?disabled=${isDisabled}

--- a/libs/react/src/lib/datepicker/datepicker.stories.mdx
+++ b/libs/react/src/lib/datepicker/datepicker.stories.mdx
@@ -25,20 +25,20 @@ Datepicker Component
 
 ### Available props
 
-| Property       | Description                                                         | Default |
-| :------------- | :------------------------------------------------------------------ | :------ |
-| label          | The label for the Datepicker.                                       | "Date"  |
-| showWeeks      | A boolean indicating whether week numbers should be shown.          |         |
-| minDate        | The minimum selectable date as a `Date` object.                     |         |
-| maxDate        | The maximum selectable date as a `Date` object.                     |         |
-| onChange       | A function that is called when the selected date changes.           |         |
-| dateFormat     | Date format for the input field. Use letters `d`, `m`, `y` to specify the order of day, month, year, separated by a delimiter. For example `y-m-d` or `d/m/y`         | y-m-d |
-| size           | The size of the input field. Can be `medium` or `large`.      | medium  |
-| hideLabel      | A boolean indicating whether the label should be hidden.            |         |
-
+| Property         | Description                                                                                                                                                   | Default |
+| :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------ |
+| label            | The label for the Datepicker.                                                                                                                                 | "Date"  |
+| showWeeks        | A boolean indicating whether week numbers should be shown.                                                                                                    |         |
+| minDate          | The minimum selectable date as a `Date` object.                                                                                                               |         |
+| maxDate          | The maximum selectable date as a `Date` object.                                                                                                               |         |
+| onChange         | A function that is called when the selected date changes.                                                                                                     |         |
+| dateFormat       | Date format for the input field. Use letters `d`, `m`, `y` to specify the order of day, month, year, separated by a delimiter. For example `y-m-d` or `d/m/y` | y-m-d   |
+| size             | The size of the input field. Can be `medium` or `large`.                                                                                                      | medium  |
+| hideLabel        | A boolean indicating whether the label should be hidden.                                                                                                      |         |
+| disabledDates    | Array of dates to disable                                                                                                                                     | `[]`    |
+| disabledWeekends | Disable all weekends in the calendar view                                                                                                                     | `false` |
 
 Props are forwarded to the underlying web component, so anything supported by `gds-datepicker` can be used. See https://sebgroup.github.io/green/latest/core/?path=/docs/components-datepicker--page for more details.
-
 
 ### Localization
 

--- a/libs/react/src/lib/datepicker/datepicker.tsx
+++ b/libs/react/src/lib/datepicker/datepicker.tsx
@@ -23,6 +23,8 @@ export interface DatepickerOptions {
   testId?: string
   size?: 'small' | 'medium'
   hideLabel?: boolean
+  disabledWeekends?: boolean
+  disabledDates?: Date[]
 
   /** @deprecated Use `value` instead */
   selectedDate?: Date


### PR DESCRIPTION
**Datepicker:** Added support for disabling dates

- `disabled-weekends` will disable all weekend days in the calendar view
- `disabled-dates` allows to specify an array of dates that should be disabled in the calendar view

Closes #615