### PR TITLE
fix: 🐛 the dropdown in react should select falsy values

### DIFF
--- a/.changeset/stale-chairs-drum.md
+++ b/.changeset/stale-chairs-drum.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': patch
+---
+
+Dropdown: Fix issue with the component not calling `onChange` for falsy values

--- a/libs/react/src/lib/dropdown/dropdown.stories.mdx
+++ b/libs/react/src/lib/dropdown/dropdown.stories.mdx
@@ -20,6 +20,7 @@ Dropdown Component
   }}
   args={{
     options: [
+      { label: 'Select', value: null },
       { label: 'Tacos', value: 'tacos' },
       { label: 'Pizza', value: 'pizza' },
       { label: 'Sushi', value: 'sushi' },
@@ -49,6 +50,7 @@ The dropdown options should be provided as an array of objects with label and va
 
 ```typescript
 const options = [
+  { label: 'Select', value: null },
   { label: 'Tacos', value: 'tacos' },
   { label: 'Pizza', value: 'pizza' },
   { label: 'Sushi', value: 'sushi' },

--- a/libs/react/src/lib/dropdown/dropdown.tsx
+++ b/libs/react/src/lib/dropdown/dropdown.tsx
@@ -96,8 +96,8 @@ export const Dropdown = ({
   ...props
 }: DropdownProps) => {
   const handleOnChange = (e: any) => {
-    if (e.detail?.value) {
-      onChange?.(e.detail.value)
+    if ('value' in e.detail) {
+        onChange?.(e.detail.value)
     }
   }
 


### PR DESCRIPTION
the dropdown in react should select falsy values like "", 0, null, undefined instead of ignoring them

✅ Closes: #1225