### PR TITLE
Fix broken dark mode for Datepicker and Dropdown

### DIFF
--- a/.changeset/little-crabs-cry.md
+++ b/.changeset/little-crabs-cry.md
@@ -1,0 +1,8 @@
+---
+'@sebgroup/chlorophyll': patch
+'@sebgroup/green-core': patch
+---
+
+**Datepicker, Dropdown**
+
+- Fix broken dark mode styles

--- a/libs/chlorophyll/scss/components/dropdown/_mixins.scss
+++ b/libs/chlorophyll/scss/components/dropdown/_mixins.scss
@@ -8,7 +8,7 @@ $z-index: tokens.$zindex-dropdown;
 $color: tokens.$text-primary-color;
 $border-color: map.get(tokens.$blue, 'light', 0);
 $background: tokens.$form-control-bg;
-$highlighted-background: var(--gds-ref-pallet-base800);
+$highlighted-background: var(--grey-1000);
 
 @mixin dropdown-trigger {
   @include button.reset;
@@ -16,7 +16,7 @@ $highlighted-background: var(--gds-ref-pallet-base800);
   @include common.padding-vertical(4);
   @include common.add-border-radius();
   @include common.add-border();
-  @include common.add-border-color(var(--gds-ref-pallet-base600));
+  @include common.add-border-color(var(--grey-800));
   @include common.add-focus('');
 
   background: $background;
@@ -33,11 +33,11 @@ $highlighted-background: var(--gds-ref-pallet-base800);
   }
 
   &:not(:disabled, .disabled, [aria-disabled]):hover {
-    --background: var(--gds-ref-pallet-base200);
-    --color: var(--gds-ref-pallet-base800);
-    background-color: var(--gds-ref-pallet-base200);
-    color: var(--gds-ref-pallet-base800);
-    border-color: var(--gds-ref-pallet-base800);
+    --background: var(--grey-400);
+    --color: var(--grey-1000);
+    background-color: var(--grey-400);
+    color: var(--grey-1000);
+    border-color: var(--grey-1000);
   }
 
   > span {
@@ -48,8 +48,8 @@ $highlighted-background: var(--gds-ref-pallet-base800);
 
   &::after {
     @include common.margin-horizontal(3);
-    border-bottom: solid 2px var(--gds-ref-pallet-base800);
-    border-left: solid 2px var(--gds-ref-pallet-base800);
+    border-bottom: solid 2px $color;
+    border-left: solid 2px $color;
     content: '';
     display: block;
     height: 0.5rem;
@@ -83,11 +83,11 @@ $highlighted-background: var(--gds-ref-pallet-base800);
 
   &:hover,
   &:focus-visible {
-    background-color: var(--gds-ref-pallet-base200);
+    background-color: var(--grey-400);
   }
 
   &:active {
-    background-color: var(--gds-ref-pallet-base300);
+    background-color: var(--grey-400);
   }
 
   &:focus {

--- a/libs/chlorophyll/scss/components/popover/_mixins.scss
+++ b/libs/chlorophyll/scss/components/popover/_mixins.scss
@@ -5,7 +5,7 @@
 $_box-shadow: var(--sg-popover-box-shadow);
 $_box-shadow-mobile: 0 -0.25rem 1rem rgba(0, 0, 0, 0.1);
 $_z-index: var(--sg-z-index-popover);
-$_border-color: var(--gds-ref-pallet-base800);
+$_border-color: var(--text-primary-color);
 $_popover-bg: var(--sg-popover-background);
 $_max-height-mobile: calc(100% - 1rem);
 $_max-height: 500px;

--- a/libs/core/src/components/datepicker/datepicker.trans.styles.scss
+++ b/libs/core/src/components/datepicker/datepicker.trans.styles.scss
@@ -45,7 +45,7 @@
     cursor: text;
 
     &:hover {
-      background-color: var(--gds-ref-pallet-base100);
+      background-color: var(--grey-200);
     }
 
     .input {
@@ -95,9 +95,10 @@
       cursor: pointer;
       width: 2.75rem;
       background: transparent;
+      color: var(--text-primary-color);
 
       &:hover {
-        background: var(--gds-ref-pallet-base300);
+        background: var(--grey-500);
       }
 
       svg {
@@ -155,7 +156,7 @@
       margin: 0.125rem 0.25rem;
 
       &:hover {
-        background: var(--gds-ref-pallet-base300);
+        background: var(--grey-400);
       }
 
       &:focus-visible {
@@ -164,8 +165,8 @@
       // TODO: Replace with proper icons
       .icon::before {
         background: none;
-        border-bottom: 2px solid;
-        border-left: 2px solid;
+        border-bottom: 2px solid var(--grey-1000);
+        border-left: 2px solid var(--grey-1000);
         content: '';
         display: block;
         height: 8px;

--- a/libs/core/src/components/dropdown/dropdown.trans.styles.scss
+++ b/libs/core/src/components/dropdown/dropdown.trans.styles.scss
@@ -70,7 +70,7 @@
       font-size: 0.875rem;
     }
     &:hover {
-      background: var(--gds-ref-pallet-base300);
+      background: var(--grey-400);
     }
   }
 

--- a/libs/core/src/primitives/calendar/_mixins.scss
+++ b/libs/core/src/primitives/calendar/_mixins.scss
@@ -18,7 +18,7 @@ $disabled-weight: 400; // regular
 
 // hover
 $hover-color: var(--gds-sys-color-font);
-$hover-background: var(--gds-ref-pallet-base300);
+$hover-background: var(--grey-500);
 $hover-border-radius: $border-radius;
 
 // focus
@@ -28,7 +28,7 @@ $focus-border-radius: $hover-border-radius;
 
 // selected
 $selected-color: hsl(var(--sg-hsl-white));
-$selected-background: var(--gds-ref-pallet-base800);
+$selected-background: var(--grey-1000);
 $selected-range-background: hsla(var(--sg-hsl-blue-2), 0.5);
 $selected-border-radius: $border-radius;
 $selected-range-border-radius: 0;

--- a/libs/core/src/primitives/listbox/option.trans.styles.scss
+++ b/libs/core/src/primitives/listbox/option.trans.styles.scss
@@ -13,11 +13,11 @@
 
   :host(:hover),
   :host(:focus-visible) {
-    background-color: var(--gds-ref-pallet-base200);
+    background-color: var(--grey-400);
   }
 
   :host(:active) {
-    background-color: var(--gds-ref-pallet-base300);
+    background-color: var(--grey-500);
   }
 
   :host(:focus) {

--- a/libs/core/src/primitives/popover/popover.trans.styles.scss
+++ b/libs/core/src/primitives/popover/popover.trans.styles.scss
@@ -38,6 +38,7 @@
     overflow: hidden;
     padding: 0;
     right: 0;
+    color: var(--text-primary-color);
 
     @include common.media-breakpoint-down('sm') {
       max-height: 80svh;


### PR DESCRIPTION
**Note:** Some gray tones will be slightly incorrect now, compared to Figma,, because only the older set of gray tokens in Chlorophyll have dark mode configured, and I reverted to using those tokens now in this PR.

The tokens (especially grey values) needs to be synced and consolidated. But that is outside the scope of this PR.

**Note 2:** To check it out in Storybook, use the React one. It is currently the only one where dark mode can be selected and works properly :)