### PR TITLE
Dropdown: Only `undefined` should be considered as "no value"

### DIFF
--- a/.changeset/shiny-bulldogs-dream.md
+++ b/.changeset/shiny-bulldogs-dream.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+Dropdown: fix issue where falsy values where considered as no values (only `undefined` should be explicitly considered as "no value") (closes #1259)

--- a/libs/core/src/components/datepicker/datepicker.test.ts
+++ b/libs/core/src/components/datepicker/datepicker.test.ts
@@ -461,7 +461,7 @@ describe('<gds-datepicker>', () => {
 
     it('should give calendar keyboard focus after opening the popover', async () => {
       const el = await fixture<GdsDatepicker>(
-        html`<gds-datepicker></gds-datepicker>`
+        html`<gds-datepicker value="2024-01-01"></gds-datepicker>`
       )
 
       const button = el.shadowRoot!.querySelector<HTMLButtonElement>(
@@ -477,7 +477,7 @@ describe('<gds-datepicker>', () => {
         press: 'Enter',
       })
 
-      expect(onlyDate(el.value!)).to.equal(onlyDate(new Date()))
+      expect(onlyDate(el.value!)).to.equal(onlyDate(new Date('2024-01-01')))
     })
 
     it('should set spinners to yyyy, mm and dd when date is undefined', async () => {

--- a/libs/core/src/components/dropdown/dropdown.ts
+++ b/libs/core/src/components/dropdown/dropdown.ts
@@ -307,7 +307,7 @@ export class GdsDropdown<ValueT = any>
     }
 
     // Set default value if none is set
-    if (!this.value) {
+    if (this.value === undefined) {
       if (this.placeholder) this.value = this.placeholder.value
       else this.value = this.options[0]?.value
     }


### PR DESCRIPTION
This is a fix for #1259