### PR TITLE
Changing placeholder datepicker format

### DIFF
--- a/.changeset/green-otters-work.md
+++ b/.changeset/green-otters-work.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Datepicker:** Use uppercase letters in placeholder to align with UX writing guidelines

--- a/libs/core/src/components/datepicker/datepicker.test.ts
+++ b/libs/core/src/components/datepicker/datepicker.test.ts
@@ -132,7 +132,7 @@ describe('<gds-datepicker>', () => {
       el.value = undefined
       await el.updateComplete
 
-      await expect(spinners[0].value.toString()).to.equal('yyyy')
+      await expect(spinners[0].value.toString()).to.equal('YYYY')
     })
 
     it('should reset when form is reset', async () => {
@@ -154,7 +154,7 @@ describe('<gds-datepicker>', () => {
       resetButton.click()
       await timeout(0)
 
-      await expect(spinners[0].value.toString()).to.equal('yyyy')
+      await expect(spinners[0].value.toString()).to.equal('YYYY')
     })
 
     it('should return a focused date', async () => {
@@ -480,7 +480,7 @@ describe('<gds-datepicker>', () => {
       expect(onlyDate(el.value!)).to.equal(onlyDate(new Date('2024-01-01')))
     })
 
-    it('should set spinners to yyyy, mm and dd when date is undefined', async () => {
+    it('should set spinners to YYYY, MM and DD when date is undefined', async () => {
       const el = await fixture<GdsDatepicker>(
         html`<gds-datepicker value="2024-01-01"></gds-datepicker>`
       )
@@ -494,9 +494,9 @@ describe('<gds-datepicker>', () => {
       await timeout(0)
       await el.updateComplete
 
-      await expect(spinners[0].value.toString()).to.equal('yyyy')
-      await expect(spinners[1].value.toString()).to.equal('mm')
-      await expect(spinners[2].value.toString()).to.equal('dd')
+      await expect(spinners[0].value.toString()).to.equal('YYYY')
+      await expect(spinners[1].value.toString()).to.equal('MM')
+      await expect(spinners[2].value.toString()).to.equal('DD')
     })
 
     it('should emit input event when navigating with arrow keys in calendar popover', async () => {

--- a/libs/core/src/components/datepicker/datepicker.ts
+++ b/libs/core/src/components/datepicker/datepicker.ts
@@ -421,9 +421,9 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
     // Reset spinner state if value is unset
     if (!this.value) {
       this.#spinnerState = {
-        year: 'yyyy',
-        month: 'mm',
-        day: 'dd',
+        year: 'YYYY',
+        month: 'MM',
+        day: 'DD',
       }
       return
     }
@@ -651,9 +651,9 @@ export class GdsDatepicker extends GdsFormControlElement<Date> {
    * The spinner state keeps track of the spinner values regardless of wheter a complete date has been enter yet.
    */
   #spinnerState = {
-    year: 'yyyy',
-    month: 'mm',
-    day: 'dd',
+    year: 'YYYY',
+    month: 'MM',
+    day: 'DD',
   }
 
   /**


### PR DESCRIPTION
According to UXW guidelines, dateformat should be in `YYYY-MM-DD`.