### PR TITLE
fix(angular/modals): slideout sizing

### DIFF
--- a/.changeset/lucky-onions-hunt.md
+++ b/.changeset/lucky-onions-hunt.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-angular': patch
+---
+
+**Slideout modal**: Update sizes to match Design Library

--- a/libs/angular/src/lib/modal/modal.component.html
+++ b/libs/angular/src/lib/modal/modal.component.html
@@ -6,8 +6,8 @@
       role="dialog"
       aria-modal="true"
       [class.small]="size === 'sm'"
-      [class.medium]="size === 'md'"
-      [class.large]="size === 'lg'"
+      [class.gds-slide-out--768]="size === 'md'"
+      [class.gds-slide-out--960]="size === 'lg'"
       [class.entered]="isOpen"
     >
       <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>


### PR DESCRIPTION
Updated slideout modal sizing in Angular to match design library

closes #[1263](https://github.com/sebgroup/green/issues/1263)