### PR TITLE
Deprecate `ValueList` and update Grouped List examples

### DIFF
--- a/.changeset/real-poets-sparkle.md
+++ b/.changeset/real-poets-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-react': patch
+---
+
+Deprecate `ValueList`

--- a/.storybook/storybook-overrides.scss
+++ b/.storybook/storybook-overrides.scss
@@ -4,14 +4,6 @@
   font-family: inherit !important;
 }
 
-.sbdocs,
-.sbdocs code,
-.docs-story > div,
-.docs-story > div > button:not(.docblock-code-toggle) {
-  background: inherit !important;
-  color: inherit !important;
-}
-
 button.docblock-code-toggle,
 .docblock-source > div > button,
 .docs-story + div > div > button {

--- a/libs/core/src/components/grouped-list/grouped-list.stories.mdx
+++ b/libs/core/src/components/grouped-list/grouped-list.stories.mdx
@@ -9,7 +9,7 @@ The `<gds-grouped-list>` element accepts `<gds-list-item>` elements as children.
 
 <Canvas>
   <div style={{ dummy: registerTransitionalStyles() }}>
-    <gds-grouped-list label="List label">
+    <gds-grouped-list label="Example of a basic list of items">
       <gds-list-item>Item 1</gds-list-item>
       <gds-list-item>Item 2</gds-list-item>
       <gds-list-item>Item 3</gds-list-item>
@@ -25,7 +25,7 @@ By default, the list items are displayed as `flex` containers with `space-betwee
 
 <Canvas>
   <div style={{ dummy: registerTransitionalStyles() }}>
-    <gds-grouped-list label="List label">
+    <gds-grouped-list label="Example with values">
       <gds-list-item>
         <div>Key 1</div>
         <strong>Value 1</strong>
@@ -54,7 +54,7 @@ By default, the list items are displayed as `flex` containers with `space-betwee
 
 <Canvas>
   <div style={{ dummy: registerTransitionalStyles() }}>
-    <gds-grouped-list label="List label">
+    <gds-grouped-list label="Example with links">
       <gds-list-item>
         <div>Key 1</div>
         <strong>Value 1</strong>
@@ -100,7 +100,7 @@ The slotted elements can be styled using inline styles or CSS classes.
 
 <Canvas>
   <div style={{ dummy: registerTransitionalStyles() }}>
-    <gds-grouped-list label="List label">
+    <gds-grouped-list label="Example of left aligned list">
       <gds-list-item
         style={{
           justifyContent: 'left',
@@ -133,6 +133,42 @@ The slotted elements can be styled using inline styles or CSS classes.
         <div>
           <a href="#">Link</a>
         </div>
+      </gds-list-item>
+    </gds-grouped-list>
+  </div>
+</Canvas>
+
+The slotted elements can be styled using inline styles or CSS classes.
+
+<Canvas>
+  <div style={{ dummy: registerTransitionalStyles() }}>
+    <gds-grouped-list label="Example of vertical list">
+      <gds-list-item
+        style={{
+          flexDirection: 'column',
+          borderWidth: 0,
+        }}
+      >
+        <div>Key 1</div>
+        <strong>Value 1</strong>
+      </gds-list-item>
+      <gds-list-item
+        style={{
+          flexDirection: 'column',
+          borderWidth: 0,
+        }}
+      >
+        <div>Key 2</div>
+        <strong>Value 2</strong>
+      </gds-list-item>
+      <gds-list-item
+        style={{
+          flexDirection: 'column',
+          borderWidth: 0,
+        }}
+      >
+        <div>Key 3</div>
+        <strong>Value 3</strong>
       </gds-list-item>
     </gds-grouped-list>
   </div>

--- a/libs/react/src/lib/list/valueList.stories.mdx
+++ b/libs/react/src/lib/list/valueList.stories.mdx
@@ -28,7 +28,9 @@ export const ValueListTemplate = ({ children, ...props }) => (
 
 <Meta title="Components/ValueList" component={ValueList} />
 
-## Value List
+## Value List <span className="badge warning" style={{ background: 'var(--background)' }}>Deprecated</span>
+
+This component is deprecated in favour of [`GroupedList`](/docs/components-grouped-list--page)
 
 <Canvas>
   <Story

--- a/libs/react/src/lib/list/valueList.tsx
+++ b/libs/react/src/lib/list/valueList.tsx
@@ -11,18 +11,34 @@ interface ValueListItemProps {
   children: string
 }
 
+/**
+ * @deprecated
+ * Use `GroupedList` instead.
+ */
 export const Label = ({ children }: ValueListItemProps) => {
   return <dt>{children}</dt>
 }
 
+/**
+ * @deprecated
+ * Use `GroupedList` instead.
+ */
 export const Value = ({ children }: ValueListItemProps) => {
   return <dd>{children}</dd>
 }
 
+/**
+ * @deprecated
+ * Use `GroupedList` instead.
+ */
 export const List = ({ children, inverted }: ValueListProps) => {
   let classNames = 'gds-list'
   if (inverted) classNames += ' gds-list--inverted'
   return <dl className={classNames}>{children}</dl>
 }
 
+/**
+ * @deprecated
+ * Use `GroupedList` instead.
+ */
 export default { List, Label, Value }


### PR DESCRIPTION
This PR adds an additional example to the Grouped list component, and marks the old `ValueList` component in React as deprecated.