### PR TITLE
Fix: Typo Grid — #1298

### DIFF
--- a/libs/core/src/components/grid/grid.stories.mdx
+++ b/libs/core/src/components/grid/grid.stories.mdx
@@ -82,7 +82,7 @@ Auto Columns, while optional, remove the need for breakpoints, adapting to conte
 </gds-grid>
 
 <!-- Using different values for each screen size -->
-<gds-grid columns="8 4 2" auto-columns="l:200 m:100 s:80">
+<gds-grid columns="l:8 m:4 s:2" auto-columns="l:200 m:100 s:80">
     <!-- Child elements here -->
 </gds-grid>
 ```


### PR DESCRIPTION
Very minor change a mistake on the grid example when using auto columns and columns combined.

Good catch @daggelito02