### PR TITLE
Add Grid `row-gap` attribute

### DIFF
--- a/.changeset/light-eels-compare.md
+++ b/.changeset/light-eels-compare.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': minor
+---
+
+Add new attribute row-gap

--- a/libs/core/src/components/grid/grid.stories.css
+++ b/libs/core/src/components/grid/grid.stories.css
@@ -1,5 +1,4 @@
 gds-grid {
-  row-gap: 1lh;
   --gds-debug-color: hsla(241, 100%, 66%, 0.4);
   --gds-debug-color-container: rgba(255, 82, 197, 0.4);
 

--- a/libs/core/src/components/grid/grid.stories.mdx
+++ b/libs/core/src/components/grid/grid.stories.mdx
@@ -10,18 +10,23 @@ The `gds-grid` is a custom element that provides a flexible grid system. It uses
 
 ## Usage
 
-To use the `gds-grid`, you add it to your HTML and specify the number of `columns` for `desktop`, `tablet`, and `mobile` devices using the `columns` attribute. The `columns`, `gap` and `padding` attributes can take either a single value or a string of three tokens separated by spaces, each prefixed with `l:` for `desktop`, `m:` for `tablet`, and `s:` for mobile.
+To use the `gds-grid`, you add it to your HTML and specify the number of `columns` for `desktop`, `tablet`, and `mobile` devices using the `columns` attribute. The `columns`, `gap`, `row-gap` and `padding` attributes can take either a single value or a string of three tokens separated by spaces, each prefixed with `l:` for `desktop`, `m:` for `tablet`, and `s:` for mobile.
 
 If a single value is provided, it will be used for all screen sizes. If three tokens are provided, each screen size will use the value specified for it.
 
 ```html
 <!-- Using a single value for all screen sizes -->
-<gds-grid columns="2" gap="xl" padding="2xl">
+<gds-grid columns="2" gap="xl" row-gap="2xl" padding="2xl">
     <!-- Child elements here -->
 </gds-grid>
 
 <!-- Using different values for each screen size -->
-<gds-grid columns="l:8 m:4 s:2" gap="l:xl m:l s:xs" padding="l:2xl m:l s:xs">
+<gds-grid 
+    columns="l:8 m:4 s:2" 
+    gap="l:xl m:l s:xs" 
+    row-gap="l:xl m:l s:xs" 
+    padding="l:2xl m:l s:xs"
+>
     <!-- Child elements here -->
 </gds-grid>
 ```
@@ -94,7 +99,7 @@ Auto Columns, while optional, remove the need for breakpoints, adapting to conte
 This example has the fluid attribute and it will adapt the content automatically based on the available width and min inline size.
 The `auto-columns` attribute is set to `240` which will make the columns to be `240px` no matter the screen/container size.
 <Canvas>
-    <gds-grid columns="2" row-gap="s" gap="s"  padding="2xl"  auto-columns="240">
+    <gds-grid auto-columns="240">
         <div>COL: 01</div>
         <div>COL: 02</div>
         <div>COL: 03</div>

--- a/libs/core/src/components/grid/grid.stories.mdx
+++ b/libs/core/src/components/grid/grid.stories.mdx
@@ -52,7 +52,8 @@ This example shows a grid with `4` columns on all breakpoints desktop, tablet, a
 <Canvas>
     <gds-grid 
         columns="4" 
-        gap="2xl" 
+        gap="l:2xl m:2xl s:2xl" 
+        row-gap="l:2xl m:2xl s:2xl" 
         padding="l" 
         auto-columns="100"
     >
@@ -72,7 +73,7 @@ This example shows a grid with `4` columns on all breakpoints desktop, tablet, a
 
 The `auto-columns` attribute makes the grid flexible by adjusting column widths based on available space and content size. If space is limited, it reduces the number of columns while maintaining a minimum column width based on the value provided. The `auto-columns` attribute can take either a single value or a string of three tokens separated by spaces, each prefixed with `l:` for `desktop`, `m:` for `tablet`, and `s:` for `mobile` respectively.
 
-It can be used without the other attributes and still fit tne content on the available width. But for more granular control it can be used with the `columns`, `gap`, and `padding` attributes.
+It can be used without the other attributes and still fit the content on the available width. But for more granular control it can be used with the `columns`, `gap`, and `padding` attributes.
 
 Auto Columns, while optional, remove the need for breakpoints, adapting to content for a more flexible and responsive grid. However, they can still be used in conjunction with breakpoints to accommodate content in both cases.
 ```html
@@ -91,9 +92,9 @@ Auto Columns, while optional, remove the need for breakpoints, adapting to conte
 
 ## Example: Auto Columns without other attributes
 This example has the fluid attribute and it will adapt the content automatically based on the available width and min inline size.
-The `auto-columns` attribute is set to `l:360 m:200 s:120` which will make the columns to be `360px` wide on desktop, `200px` wide on tablet, and `120px` wide on mobile.
+The `auto-columns` attribute is set to `240` which will make the columns to be `240px` no matter the screen/container size.
 <Canvas>
-    <gds-grid auto-columns="l:360 m:200 s:120" >
+    <gds-grid columns="2" row-gap="s" gap="s"  padding="2xl"  auto-columns="240">
         <div>COL: 01</div>
         <div>COL: 02</div>
         <div>COL: 03</div>
@@ -109,12 +110,25 @@ The `auto-columns` attribute is set to `l:360 m:200 s:120` which will make the c
 ## Sizes
 Sizes ref are part of the internal design system and are used to define the `gap` and `padding` for different devices. The following are the available sizes:
 ```
-3xl:  size/12
-2xl:  size/9
-xl:   size/7
-l:    size/6
-m:    size/5
-s:    size/3
-xs:   size/2
-none: size/0
+3xl:  size/12 = 96px
+2xl:  size/9 = 48px
+xl:   size/7 = 32px
+l:    size/6 = 24px
+m:    size/5 = 16px
+s:    size/3 = 8px
+xs:   size/2 = 4px
+none: size/0 = 0px
+```
+
+## Breakpoints
+The grid component has three breakpoints for `desktop`, `tablet`, and `mobile` devices. The following are the available breakpoints:
+```
+L (desktop) 
+    desktop-lg: 2560px
+    desktop-md: 1440px
+    desktop-sm: 1024px
+M (tablet)
+    tablet: 768px
+S (mobile)
+    mobile: 425px
 ```

--- a/libs/core/src/components/grid/grid.stories.mdx
+++ b/libs/core/src/components/grid/grid.stories.mdx
@@ -16,7 +16,11 @@ If a single value is provided, it will be used for all screen sizes. If three to
 
 ```html
 <!-- Using a single value for all screen sizes -->
-<gds-grid columns="2" gap="xl" row-gap="2xl" padding="2xl">
+<gds-grid 
+    columns="2" 
+    gap="xl" 
+    row-gap="2xl" 
+    padding="2xl" >
     <!-- Child elements here -->
 </gds-grid>
 
@@ -25,8 +29,7 @@ If a single value is provided, it will be used for all screen sizes. If three to
     columns="l:8 m:4 s:2" 
     gap="l:xl m:l s:xs" 
     row-gap="l:xl m:l s:xs" 
-    padding="l:2xl m:l s:xs"
->
+    padding="l:2xl m:l s:xs" >
     <!-- Child elements here -->
 </gds-grid>
 ```
@@ -99,41 +102,40 @@ Auto Columns, while optional, remove the need for breakpoints, adapting to conte
 This example has the fluid attribute and it will adapt the content automatically based on the available width and min inline size.
 The `auto-columns` attribute is set to `240` which will make the columns to be `240px` no matter the screen/container size.
 <Canvas>
-    <gds-grid auto-columns="240">
-        <div>COL: 01</div>
-        <div>COL: 02</div>
-        <div>COL: 03</div>
-        <div>COL: 04</div>
-        <div>COL: 05</div>
-        <div>COL: 06</div>
-        <div>COL: 07</div>
-        <div>COL: 08</div>
-    </gds-grid>
+<gds-grid auto-columns="240">
+    <div>COL: 01</div>
+    <div>COL: 02</div>
+    <div>COL: 03</div>
+    <div>COL: 04</div>
+    <div>COL: 05</div>
+    <div>COL: 06</div>
+    <div>COL: 07</div>
+    <div>COL: 08</div>
+</gds-grid>
 </Canvas>
 
 
 ## Sizes
 Sizes ref are part of the internal design system and are used to define the `gap` and `padding` for different devices. The following are the available sizes:
-```
-3xl:  size/12 = 96px
-2xl:  size/9 = 48px
-xl:   size/7 = 32px
-l:    size/6 = 24px
-m:    size/5 = 16px
-s:    size/3 = 8px
-xs:   size/2 = 4px
-none: size/0 = 0px
-```
+
+| Size | Token       | Pixels |
+|------|-------------|--------|
+| 3xl  | size/12     | 96px   |
+| 2xl  | size/9      | 48px   |
+| xl   | size/7      | 32px   |
+| l    | size/6      | 24px   |
+| m    | size/5      | 16px   |
+| s    | size/3      | 8px    |
+| xs   | size/2      | 4px    |
+| none | size/0      | 0px    |
 
 ## Breakpoints
 The grid component has three breakpoints for `desktop`, `tablet`, and `mobile` devices. The following are the available breakpoints:
-```
-L (desktop) 
-    desktop-lg: 2560px
-    desktop-md: 1440px
-    desktop-sm: 1024px
-M (tablet)
-    tablet: 768px
-S (mobile)
-    mobile: 425px
-```
+
+| Category | Type       | Size   |
+|----------|------------|--------|
+| L        | desktop-lg | 2560px |
+| L        | desktop-md | 1440px |
+| L        | desktop-sm | 1024px |
+| M        | tablet     | 768px  |
+| S        | mobile     | 425px  |

--- a/libs/core/src/components/grid/grid.style.css.ts
+++ b/libs/core/src/components/grid/grid.style.css.ts
@@ -10,10 +10,12 @@ const style = css`
       --_grid-col-start: 1;
       --_grid-col-end: -1;
       --_gap-column: 0;
+      --_gap-row: 0;
       display: grid;
       width: 100%;
       grid-template-columns: var(--_grid-col);
       grid-column-gap: var(--_gap-column);
+      grid-row-gap: var(--_gap-row);
       padding: var(--_grid-padding);
       text-wrap: balance;
     }
@@ -36,23 +38,26 @@ const style = css`
   :host {
     --_c: var(--_columns-desktop);
     --_gap-column: var(--_gap-desktop);
+    --_gap-row: var(--_row-gap-desktop);
     --_grid-padding: var(--_padding-desktop);
     --_col-width: var(--_col-width-desktop);
   }
 
   @media only screen and (max-width: 768px) {
-    :host(:not([auto-columns])) {
+    :host {
       --_c: var(--_columns-tablet);
       --_gap-column: var(--_gap-tablet);
+      --_gap-row: var(--_row-gap-tablet);
       --_grid-padding: var(--_padding-tablet);
       --_col-width: var(--_col-width-tablet);
     }
   }
 
   @media only screen and (max-width: 425px) {
-    :host(:not([auto-columns])) {
+    :host {
       --_c: var(--_columns-mobile);
       --_gap-column: var(--_gap-mobile);
+      --_gap-row: var(--_row-gap-mobile);
       --_grid-padding: var(--_padding-mobile);
       --_col-width: var(--_col-width-mobile);
     }

--- a/libs/core/src/components/grid/grid.ts
+++ b/libs/core/src/components/grid/grid.ts
@@ -46,7 +46,7 @@ export class GdsGrid extends LitElement {
   columns?: string | undefined
 
   /**
-   * @property {string} gap - Defines the gap size between grid items. Accepts a single value for all breakpoints or a "l:desktop m:tablet s:mobile" format. Sizes can be 'none', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl'.
+   * @property {string} `gap` - Defines the gap size between grid items. Accepts a single value for all breakpoints or a "l:desktop m:tablet s:mobile" format. Sizes can be 'none', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl'.
    * @example
    * ```html
    * <gds-grid gap="m"></gds-grid> <!-- applies to all breakpoints -->
@@ -55,6 +55,17 @@ export class GdsGrid extends LitElement {
    */
   @property({ attribute: 'gap', type: String })
   gap?: GridSizes
+
+  /**
+   * @property {string} `row-gap` - Defines the gap size between grid items in vertical axis. Accepts a single value for all breakpoints or a "l:desktop m:tablet s:mobile" format. Sizes can be 'none', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl'.
+   * @example
+   * ```html
+   * <gds-grid row-gap="m"></gds-grid> <!-- applies to all breakpoints -->
+   * <gds-grid row-gap="l:m m:s s:xs"></gds-grid> <!-- different values for each breakpoint -->
+   * ```
+   */
+  @property({ attribute: 'row-gap', type: String })
+  rowGap?: GridSizes
 
   /**
    * @property {string} padding - Defines the padding size around the grid. Accepts a single value for all breakpoints or a "l:desktop m:tablet s:mobile" format. Sizes can be 'none', 'xs', 's', 'm', 'l', 'xl', '2xl', '3xl'.
@@ -86,6 +97,7 @@ export class GdsGrid extends LitElement {
     super.connectedCallback()
     this._updateColumnVariables()
     this._updateGapVariables()
+    this._updateRowGapVariables()
     this._updatePaddingVariables()
     this._updateAutoColumnsVariables()
   }
@@ -97,6 +109,7 @@ export class GdsGrid extends LitElement {
   private _gridVariables = {
     varsColumn: css``,
     varsGap: css``,
+    varsRowGap: css``,
     varsPadding: css``,
     varsAutoColumns: css``,
   }
@@ -174,6 +187,54 @@ export class GdsGrid extends LitElement {
     this._gridVariables = {
       ...this._gridVariables,
       varsGap: css`
+        ${unsafeCSS(cssVariables)}
+      `,
+    }
+
+    this.requestUpdate('_gridVariables')
+  }
+  /**
+   * Watcher for the 'row-gap' property.
+   * It updates the row-gap CSS variables when the 'row-gap' property changes.
+   */
+  @watch('row-gap')
+  private _updateRowGapVariables() {
+    const match = this.rowGap?.match(BreakpointPattern)
+    let rowGapDesktop, rowGapTablet, rowGapMobile
+
+    if (this.rowGap && !this.rowGap.includes(' ')) {
+      // If gap is a single value, use it for all screen sizes
+      rowGapDesktop =
+        rowGapTablet =
+        rowGapMobile =
+          `var(--gds-sys-grid-gap-${this.rowGap})`
+    } else {
+      const { l, m, s } = match?.groups || {}
+      rowGapDesktop = l
+        ? `var(--gds-sys-grid-gap-${l.split(':')[1]})`
+        : undefined
+      rowGapTablet = m
+        ? `var(--gds-sys-grid-gap-${m.split(':')[1]})`
+        : undefined
+      rowGapMobile = s
+        ? `var(--gds-sys-grid-gap-${s.split(':')[1]})`
+        : undefined
+    }
+
+    const gapProperties = [
+      { name: '_row-gap-desktop', value: rowGapDesktop },
+      { name: '_row-gap-tablet', value: rowGapTablet },
+      { name: '_row-gap-mobile', value: rowGapMobile },
+    ]
+
+    const cssVariables = gapProperties
+      .filter(({ value }) => value !== undefined)
+      .map(({ name, value }) => `--${name}: ${value};`)
+      .join(' ')
+
+    this._gridVariables = {
+      ...this._gridVariables,
+      varsRowGap: css`
         ${unsafeCSS(cssVariables)}
       `,
     }


### PR DESCRIPTION
Add a new `row-gap` attribute to control the vertical axis of the gap. 
Has the exact same functionality as the default `gap` attribute. 

Additionally updated documentation to clarify sizes and breakpoints. 
Brought back breakpoints on all settings to avoid conflicts and misconfigurations. 