### PR TITLE
Fix `gds-icon` element scoping

### DIFF
--- a/.changeset/mean-foxes-shout.md
+++ b/.changeset/mean-foxes-shout.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**gds-icon**: Fix element scoping

--- a/libs/core/src/components/icon/icon.ts
+++ b/libs/core/src/components/icon/icon.ts
@@ -1,11 +1,13 @@
-import { LitElement, html, unsafeCSS } from 'lit'
-import { customElement } from 'lit/decorators.js'
+import { LitElement, unsafeCSS } from 'lit'
+import {
+  gdsCustomElement,
+  html,
+} from '../../utils/helpers/custom-element-scoping'
 
 import styles from './stem.styles.scss'
 
-// Add "lib" Attribute for Font-Awesome or similar packages
 
-@customElement('gds-icon')
+@gdsCustomElement('gds-icon')
 export class GdsIcon extends LitElement {
   static get styles() {
     return unsafeCSS(styles)


### PR DESCRIPTION
`gds-icon` was using the wrong custom element decorator, causing it to register unscoped.