### PR TITLE
Add property for columns to fix init count on safari

### DIFF
--- a/.changeset/honest-actors-do.md
+++ b/.changeset/honest-actors-do.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": patch
+---
+
+Grid fix for Safari, initial value

--- a/libs/core/src/components/grid/grid.style.css.ts
+++ b/libs/core/src/components/grid/grid.style.css.ts
@@ -5,7 +5,7 @@ const style = css`
 
   @property --_c {
     syntax: '<number>';
-    inherits: false;
+    inherits: true;
     initial-value: 0;
   }
 
@@ -41,8 +41,12 @@ const style = css`
   }
 
   /* Responsive */
-  :host {
+
+  :host([columns]) {
     --_c: var(--_columns-desktop);
+  }
+
+  :host {
     --_gap-column: var(--_gap-desktop);
     --_gap-row: var(--_row-gap-desktop);
     --_grid-padding: var(--_padding-desktop);
@@ -50,8 +54,11 @@ const style = css`
   }
 
   @media only screen and (max-width: 768px) {
-    :host {
+    :host([columns]) {
       --_c: var(--_columns-tablet);
+    }
+
+    :host {
       --_gap-column: var(--_gap-tablet);
       --_gap-row: var(--_row-gap-tablet);
       --_grid-padding: var(--_padding-tablet);
@@ -60,6 +67,10 @@ const style = css`
   }
 
   @media only screen and (max-width: 425px) {
+    :host([columns]) {
+      --_c: var(--_columns-mobile);
+    }
+
     :host {
       --_c: var(--_columns-mobile);
       --_gap-column: var(--_gap-mobile);

--- a/libs/core/src/components/grid/grid.style.css.ts
+++ b/libs/core/src/components/grid/grid.style.css.ts
@@ -3,12 +3,6 @@ import { css } from 'lit'
 const style = css`
   @layer grid, grid.desktop, grid.tablet, grid.mobile, grid.span, grid.space, grid.align, grid.debug;
 
-  @property --_c {
-    syntax: '<number>';
-    inherits: true;
-    initial-value: 0;
-  }
-
   @layer grid {
     :host {
       --_c: var(--gds-sys-grid-columns-12);

--- a/libs/core/src/components/grid/grid.style.css.ts
+++ b/libs/core/src/components/grid/grid.style.css.ts
@@ -3,6 +3,12 @@ import { css } from 'lit'
 const style = css`
   @layer grid, grid.desktop, grid.tablet, grid.mobile, grid.span, grid.space, grid.align, grid.debug;
 
+  @property --_c {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 0;
+  }
+
   @layer grid {
     :host {
       --_c: var(--gds-sys-grid-columns-12);


### PR DESCRIPTION
This is a minor fix for Safari where it would not get properly the initial count as zero and then it caused the auto columns to stop working entirely! 