### PR TITLE
Fix Accordion dark mode

### DIFF
--- a/.changeset/light-dots-sleep.md
+++ b/.changeset/light-dots-sleep.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/chlorophyll": patch
+---
+
+**Accordion:** Fix dark mode colors

--- a/libs/chlorophyll/scss/components/accordion/_mixins.scss
+++ b/libs/chlorophyll/scss/components/accordion/_mixins.scss
@@ -1,10 +1,10 @@
 @use '../../tokens';
 
 @mixin add-accordion() {
-  border-bottom: 0.0625rem solid var(--grey-500);
+  border-bottom: 0.0625rem solid var(--grey-600);
 
   & > div {
-    border-top: 0.0625rem solid var(--grey-500);
+    border-top: 0.0625rem solid var(--grey-600);
 
     svg {
       height: 1.5rem;
@@ -15,7 +15,7 @@
       background-color: var(--grey-200);
 
       & button:hover {
-        background-color: var(--grey-400);
+        background-color: var(--grey-500);
       }
 
       svg {
@@ -36,7 +36,7 @@
       background-color: transparent;
       padding: 1rem 5rem 1rem 1rem;
       border-radius: var(--gds-sys-shape-corner-none);
-      color: var(--grey-1000);
+      color: var(--text-primary-color);
       position: relative;
 
       > span {
@@ -55,10 +55,11 @@
         top: 1rem;
         right: 1rem;
         transition: transform tokens.$transition-time;
+        stroke: currentColor;
       }
 
       &:not([aria-expanded='true']):hover {
-        background-color: var(--grey-200);
+        background-color: var(--grey-400);
         color: var(--grey-1000);
       }
     }

--- a/libs/chlorophyll/scss/components/accordion/_mixins.scss
+++ b/libs/chlorophyll/scss/components/accordion/_mixins.scss
@@ -1,10 +1,10 @@
 @use '../../tokens';
 
 @mixin add-accordion() {
-  border-bottom: 0.0625rem solid var(--gds-ref-pallet-base300);
+  border-bottom: 0.0625rem solid var(--grey-500);
 
   & > div {
-    border-top: 0.0625rem solid var(--gds-ref-pallet-base300);
+    border-top: 0.0625rem solid var(--grey-500);
 
     svg {
       height: 1.5rem;
@@ -12,10 +12,10 @@
     }
 
     &:has(button[aria-expanded='true']) {
-      background-color: var(--gds-ref-pallet-base100);
+      background-color: var(--grey-200);
 
       & button:hover {
-        background-color: var(--gds-ref-pallet-base200);
+        background-color: var(--grey-400);
       }
 
       svg {
@@ -36,7 +36,7 @@
       background-color: transparent;
       padding: 1rem 5rem 1rem 1rem;
       border-radius: var(--gds-sys-shape-corner-none);
-      color: var(--gds-sys-color-base);
+      color: var(--grey-1000);
       position: relative;
 
       > span {
@@ -58,8 +58,8 @@
       }
 
       &:not([aria-expanded='true']):hover {
-        background-color: var(--gds-ref-pallet-base100);
-        color: var(--gds-sys-color-base);
+        background-color: var(--grey-200);
+        color: var(--grey-1000);
       }
     }
   }


### PR DESCRIPTION
This PR reverts gray scale variables in Accordion to the older `--grey-xxx`, since these have working dark mode equivalents. This is a temporary fix until we have proper dark mode tokens in place.