### PR TITLE
Republish angular

### DIFF
--- a/.changeset/lucky-weeks-cross.md
+++ b/.changeset/lucky-weeks-cross.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-angular": patch
+---
+
+Publish previously failed version


### PR DESCRIPTION
Due to previous merge issues, 3.6.1 had already been published, so we need to bump it again.