### PR TITLE
Code splitting for Angular and Transitional styles

### DIFF
--- a/.changeset/afraid-bees-end.md
+++ b/.changeset/afraid-bees-end.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-core": minor
+---
+
+**Transitional styles:** Transitional styles can now be separately imported on a per-component basis

--- a/.changeset/serious-brooms-grab.md
+++ b/.changeset/serious-brooms-grab.md
@@ -1,0 +1,5 @@
+---
+"@sebgroup/green-angular": minor
+---
+
+**Sub-packages:** Components in `@sebgroup/green-angular` are now exported as separate sub-packages for better tree-shaking.

--- a/libs/angular/project.json
+++ b/libs/angular/project.json
@@ -12,8 +12,7 @@
       "inputs": ["core"],
       "options": {
         "project": "libs/angular/ng-package.json",
-        "tsConfig": "libs/angular/tsconfig.lib.prod.json",
-        "updateBuildableProjectDepsInPackageJson": false
+        "tsConfig": "libs/angular/tsconfig.lib.prod.json"
       },
       "configurations": {
         "production": {

--- a/libs/angular/src/lib/accordion/ng-package.json
+++ b/libs/angular/src/lib/accordion/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/badge/ng-package.json
+++ b/libs/angular/src/lib/badge/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/button/ng-package.json
+++ b/libs/angular/src/lib/button/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/cell-table/ng-package.json
+++ b/libs/angular/src/lib/cell-table/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -7,7 +7,7 @@ import {
   EventEmitter,
   TemplateRef,
 } from '@angular/core'
-import { DropdownOption } from '../dropdown/dropdown.component'
+import { DropdownOption } from '@sebgroup/green-angular/src/lib/dropdown'
 
 /**
  * MenuItems extends DropDown option and adds the posibility to pass a custom template for just one item.

--- a/libs/angular/src/lib/context-menu/context-menu.component.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.component.ts
@@ -17,7 +17,7 @@ interface MenuItems extends DropdownOption {
 }
 
 import '@sebgroup/green-core/components/context-menu/index.js'
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
+import * as ContextMenuTransStyles from '@sebgroup/green-core/components/context-menu/context-menu.trans.styles.js'
 
 @Component({
   selector: 'ngg-context-menu',
@@ -62,7 +62,7 @@ export class NggContextMenuComponent {
   isActive = false
 
   constructor(private elementRef: ElementRef<HTMLElement>) {
-    registerTransitionalStyles()
+    ContextMenuTransStyles.register()
   }
 
   get placement(): string {

--- a/libs/angular/src/lib/context-menu/context-menu.module.ts
+++ b/libs/angular/src/lib/context-menu/context-menu.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common'
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { NggContextMenuComponent } from './context-menu.component'
-import { NggCoreWrapperModule } from '../shared/core-element/core-element.module'
+import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 
 @NgModule({
   declarations: [NggContextMenuComponent],

--- a/libs/angular/src/lib/context-menu/ng-package.json
+++ b/libs/angular/src/lib/context-menu/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/datepicker/datepicker.component.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.component.ts
@@ -18,7 +18,7 @@ import { randomId } from '@sebgroup/extract'
 import { endOfDay, startOfDay } from 'date-fns'
 
 import '@sebgroup/green-core/components/datepicker/index.js'
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
+import * as DatepickerTransStyles from '@sebgroup/green-core/components/datepicker/datepicker.trans.styles.js'
 
 export interface Attributes {
   id?: string
@@ -118,7 +118,7 @@ export class NggDatepickerComponent
   }
 
   constructor(private _cdr: ChangeDetectorRef) {
-    registerTransitionalStyles()
+    DatepickerTransStyles.register()
   }
 
   writeValue(value: any): void {

--- a/libs/angular/src/lib/datepicker/datepicker.module.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.module.ts
@@ -1,12 +1,11 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { NggDatepickerComponent } from './datepicker.component'
-import { NggDropdownModule } from '@sebgroup/green-angular/src/lib/dropdown'
 import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 
 @NgModule({
   declarations: [NggDatepickerComponent],
-  imports: [CommonModule, NggDropdownModule, NggCoreWrapperModule],
+  imports: [CommonModule, NggCoreWrapperModule],
   exports: [NggDatepickerComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })

--- a/libs/angular/src/lib/datepicker/datepicker.module.ts
+++ b/libs/angular/src/lib/datepicker/datepicker.module.ts
@@ -1,8 +1,8 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { CommonModule } from '@angular/common'
 import { NggDatepickerComponent } from './datepicker.component'
-import { NggDropdownModule } from '../dropdown/dropdown.module'
-import { NggCoreWrapperModule } from '../shared/core-element/core-element.module'
+import { NggDropdownModule } from '@sebgroup/green-angular/src/lib/dropdown'
+import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 
 @NgModule({
   declarations: [NggDatepickerComponent],

--- a/libs/angular/src/lib/datepicker/ng-package.json
+++ b/libs/angular/src/lib/datepicker/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/dropdown/dropdown.component.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.component.ts
@@ -26,7 +26,8 @@ import type {
   GdsDropdown,
   GdsOption,
 } from '@sebgroup/green-core/components/dropdown/index.js'
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
+
+import * as DropdownTransStyles from '@sebgroup/green-core/components/dropdown/dropdown.trans.styles.js'
 
 export type CompareWith<T = any> = (o1: T, o2: T) => boolean
 export type SearchFilter<T = any> = (search: string, value: T) => boolean
@@ -171,7 +172,7 @@ export class NggDropdownComponent implements ControlValueAccessor, OnInit {
     @Inject(Injector) private injector: Injector,
     private _cdr: ChangeDetectorRef,
   ) {
-    registerTransitionalStyles()
+    DropdownTransStyles.register()
   }
 
   ngOnInit(): void {

--- a/libs/angular/src/lib/dropdown/dropdown.module.ts
+++ b/libs/angular/src/lib/dropdown/dropdown.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common'
 import { NggDropdownComponent } from './dropdown.component'
 import { NggDropdownOptionDirective } from './dropdown-option.directive'
 import { NggDropdownButtonDirective } from './dropdown-button.directive'
-import { NggCoreWrapperModule } from '../shared/core-element/core-element.module'
+import { NggCoreWrapperModule } from '@sebgroup/green-angular/src/lib/shared'
 
 @NgModule({
   declarations: [

--- a/libs/angular/src/lib/dropdown/ng-package.json
+++ b/libs/angular/src/lib/dropdown/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/grouped-list/grouped-list.docs.mdx
+++ b/libs/angular/src/lib/grouped-list/grouped-list.docs.mdx
@@ -35,7 +35,7 @@ import '@sebgroup/green-core/components/grouped-list/index.js'
 // import type { GdsGroupedList } from '@sebgroup/green-core/components/grouped-list/index.js'
 
 // Transitional styles will make the component get 2016 design
-import * as GroupedListTransStyles from '@sebgroup/green-core/components/grouped-list/grouped-list.transcode.styles.js'
+import * as GroupedListTransStyles from '@sebgroup/green-core/components/grouped-list/grouped-list.trans.styles.js'
 // Call this fuction to register the transitional styles
 GroupedListTransStyles.register()
 // This will load 2016 styles for all instances of Grouped List in the current document.

--- a/libs/angular/src/lib/grouped-list/grouped-list.docs.mdx
+++ b/libs/angular/src/lib/grouped-list/grouped-list.docs.mdx
@@ -16,7 +16,7 @@ Add the `CUSTOM_ELEMENTS_SCHEMA` in the module that uses this component.
 
 ```ts
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core'
-import { NggCoreWrapperModule } from '@sebgroup/green-angular'
+import { NggCoreWrapperModule } from '@sebgroup/green-angular/common'
 
 @NgModule({
     // Add the NggCoreWrapperModule to the `imports` array
@@ -26,19 +26,19 @@ import { NggCoreWrapperModule } from '@sebgroup/green-angular'
 })
 ```
 
-Import `GdsGroupedList`, `registerTransitionalStyles` and `NggCoreWrapperModule` from `@sebgroup/green-core` in the Angular component that uses it.
+Import dependencies in the Angular component that uses it.
 
 ```ts
 import '@sebgroup/green-core/components/grouped-list/index.js'
 
 // if you need to interact with the component through the DOM, you can also import the class type like this:
-// import type { GdsGroupedList } from '@sebgroup/green-core/components/grouped-list'
+// import type { GdsGroupedList } from '@sebgroup/green-core/components/grouped-list/index.js'
 
 // Transitional styles will make the component get 2016 design
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
+import * as GroupedListTransStyles from '@sebgroup/green-core/components/grouped-list/grouped-list.transcode.styles.js'
 // Call this fuction to register the transitional styles
-registerTransitionalStyles()
-// This will load 2016 styles for all Green Core elements in the current document
+GroupedListTransStyles.register()
+// This will load 2016 styles for all instances of Grouped List in the current document.
 ```
 
 Use the webcomponent in your template with the `*nggCoreElement` directive.

--- a/libs/angular/src/lib/in-page-wizard/ng-package.json
+++ b/libs/angular/src/lib/in-page-wizard/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/modal/ng-package.json
+++ b/libs/angular/src/lib/modal/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/pagination/ng-package.json
+++ b/libs/angular/src/lib/pagination/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/progress-circle/ng-package.json
+++ b/libs/angular/src/lib/progress-circle/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/segmented-control/ng-package.json
+++ b/libs/angular/src/lib/segmented-control/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/shared/index.ts
+++ b/libs/angular/src/lib/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './shared.module'
 export * from './on-scroll.directive'
+export * from './core-element'

--- a/libs/angular/src/lib/shared/ng-package.json
+++ b/libs/angular/src/lib/shared/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/slider/ng-package.json
+++ b/libs/angular/src/lib/slider/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/angular/src/lib/sortable-list/ng-package.json
+++ b/libs/angular/src/lib/sortable-list/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "index.ts"
+  }
+}

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -31,8 +31,8 @@ import { css, customElement, LitElement } from 'lit'
 // This custom `html` template literal tag from Green Core extends the default `lit-html` tag to handle element version scoping.
 import { html } from '@sebgroup/green-core/scoping'
 
-// Trtansitional styles applies the current 2016 design language to the components
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
+// Transitional styles applies the current 2016 design language to the components
+import * as ButtonStyles from '@sebgroup/green-core/components/button/button.trans.styles.js'
 
 // Import the components that you need
 import '@sebgroup/green-core/components/button/index.js'
@@ -45,7 +45,7 @@ export class MyApp extends LitElement {
     super.connectedCallback()
 
     // Register transitional styles to get SEB's current visual design
-    registerTransitionalStyles()
+    ButtonStyles.register()
   }
 
   render() {
@@ -82,8 +82,8 @@ In your component:
 import '@sebgroup/green-core/components/button/index.js'
 
 // Transitional styles
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
-registerTransitionalStyles()
+import * as ButtonStyles from '@sebgroup/green-core/components/button/button.trans.styles.js'
+ButtonStyles.register()
 ```
 
 Use the webcomponent in your template with the `*nggCoreElement` directive.
@@ -108,9 +108,9 @@ import { createComponent } from '@lit/react'
 
 import { GdsButton } from '@sebgroup/green-core/component/button/index.js'
 import { getScopedTagName } from '@sebgroup/green-core/scoping'
-import { registerTransitionalStyles } from '@sebgroup/green-core/transitional-styles'
 
-registerTransitionalStyles()
+import * as ButtonStyles from '@sebgroup/green-core/components/button/button.trans.styles.js'
+ButtonStyles.register()
 
 export const Button = createComponent({
   tagName: getScopedTagName('gds-button'),

--- a/libs/core/docs/transitional-styles.md
+++ b/libs/core/docs/transitional-styles.md
@@ -2,21 +2,28 @@
 
 Transitional Styles is a temporary mechanism that we have in place to facilitate the transition of the old 2016 design version over to the new 2023 design version.
 
-The idea is that the Core Components will use the 2023 design by default, but will also have alternative "transitional styles" representing the 2016 version. By calling a function called `registerTransitionalStyles()`, the consuming application can enable these styles, which will then override the 2023 styling by replacing the interanl Contructed Stylesheet of the compoments.
+The idea is that the Core Components will use the 2023 design by default, but will also have alternative "transitional styles" representing the 2016 version. By calling a function called `register()` (or `registerTransitionalStyles()` to do it globally), the consuming application can enable these styles, which will then override the 2023 styling by replacing the internal Contructed Stylesheet of the components.
 
 The mechanism consist of a few different parts:
 
 - A singleton called `TransitionalStyles`, which keeps track of all registered transistional styles.
-- The actual stylesheets for each component. To support Transitional Styles, a component should have a separate file named `component-name.styles.trans.ts`, which exports a function called `register()`. This function registers the tranitional styles with the singleton.
+- The actual stylesheets for each component. To support Transitional Styles, a component should have a separate file named `component-name.styles.trans.ts`, which exports a function called `register()`. This function registers the transitional styles with the singleton.
 - A call to apply transitional styles in the `connectedCallback()` method in each component. The call can look like this `TransitionalStyles.instance.apply(this, 'gds-dropdown')`. This will replace the stylesheet of the component with the on that has been registered with the singleton, if it exists.
+- A function called `registerTransitionalStyles()` that calls `register()` on all the components. This will load _all_ transitional styles, and prevents tree-shaking, so it should only be used if all the styles are really needed.
 
-If `registerTransitionalStyles()` has not been called, the components will simple use the default 2023 styling.
+If `register()`, or `registerTransitionalStyles()`, has not been called, the components will simple use the default 2023 styling.
 
 # How to add transitional styles to a component
 
 1. Create these files in the component directory: `component-name.trans.styles.ts` and `component-name.trans.styles.scss`. The `scss`-file can import styles from Chlorophyll, through releative paths (not from node_modules). If necessarary, the styles can be copied from Chlorophyll and modified as needed.
-2. The `.ts` module should a) import the `scss`, and b) export a `register()` function. The register function should register the imported styles with the `TransistionalStyles` singleton. Check for example `gds-dropdown` for reference.
+2. The `.ts` module should a) import the `scss` for this component, b) import the `trans.ts` from any sub-components that this components depends on, and c) export a `register()` function. The register function should register the imported styles with the `TransistionalStyles` singleton and also call `register()` on the imported sub-components. Check for example `gds-dropdown` for reference.
 3. Import the `.ts` file in the `transitional-styles.ts` module and add a call to the `register()` function in the `registerTransitionalStyles()` function.
 4. In the `connectedCallback()` function of the component, call `TransitionalStyles.instance.apply(this, 'component-name')`
 
-That should be it! Now, when the `registerTransitionalStyles()` function is called, the component should switch to the transitional styles.
+That should be it! Now, when the `register()` function is called, the component should switch to the transitional styles.
+
+# Tree-shaking
+
+In order for transitional styles to be tree-shakable, it's important to make it possible to import the styles separately for individual components. This means that every component also needs to be responsible for forwarding the `register()` call to any sub-components it depends on. This includes both "primitives" and regular components. For example, `gds-datepicker` use both `gds-dropdown` (component), `gds-popover` (primitive) and `gds-calendar` (primitive). So in the `register()` function of `gds-datepicker` we also need to call the `register()` function of all these sub-components. Also, if a primitive depends on other primitives or components, the same applies there. The point is that the consumber of Green Core should only need to remember to call `register()` on the component they are using, and not have to worry about what other components are used internally.
+
+This may lead to the `register()` function being called several times for some components, but that is fine.

--- a/libs/core/src/components/context-menu/context-menu.trans.styles.ts
+++ b/libs/core/src/components/context-menu/context-menu.trans.styles.ts
@@ -1,8 +1,13 @@
 import { TransitionalStyles } from '../../utils/transitional-styles/transitional-styles'
 import styles from './context-menu.trans.styles.scss'
 
+import * as Popover from '../../primitives/popover/popover.trans.styles'
+import * as Listbox from '../../primitives/listbox/listbox.trans.styles'
+
 export function register() {
   TransitionalStyles.instance.register('gds-context-menu', styles.toString())
+  Popover.register()
+  Listbox.register()
 }
 
 export default register

--- a/libs/core/src/components/datepicker/datepicker.trans.styles.ts
+++ b/libs/core/src/components/datepicker/datepicker.trans.styles.ts
@@ -1,8 +1,16 @@
 import { TransitionalStyles } from '../../utils/transitional-styles/transitional-styles'
 import styles from './datepicker.trans.styles.scss'
 
+import * as Dropdown from '../dropdown/dropdown.trans.styles'
+import * as Popover from '../../primitives/popover/popover.trans.styles'
+import * as Calendar from '../../primitives/calendar/calendar.trans.styles'
+
 export function register() {
   TransitionalStyles.instance.register('gds-datepicker', styles.toString())
+  // Since dropdown is used internally in datepicker, we need to register it here
+  Dropdown.register()
+  Popover.register()
+  Calendar.register()
 }
 
 export default register

--- a/libs/core/src/components/dropdown/dropdown.trans.styles.ts
+++ b/libs/core/src/components/dropdown/dropdown.trans.styles.ts
@@ -1,7 +1,12 @@
 import { TransitionalStyles } from '../../utils/transitional-styles/transitional-styles'
 import styles from './dropdown.trans.styles.scss'
 
+import * as Listbox from '../../primitives/listbox/listbox.trans.styles'
+import * as Popover from '../../primitives/popover/popover.trans.styles'
+
 export function register() {
+  Listbox.register()
+  Popover.register()
   TransitionalStyles.instance.register('gds-dropdown', styles.toString())
 }
 

--- a/libs/core/src/components/segmented-control/segmented-control.trans.styles.ts
+++ b/libs/core/src/components/segmented-control/segmented-control.trans.styles.ts
@@ -1,11 +1,14 @@
 import { TransitionalStyles } from '../../utils/transitional-styles/transitional-styles'
 import styles from './segmented-control.trans.styles.css'
 
+import * as Segment from './segment/segment.trans.styles'
+
 export function register() {
   TransitionalStyles.instance.register(
     'gds-segmented-control',
     styles.toString(),
   )
+  Segment.register()
 }
 
 export default register

--- a/libs/core/src/utils/transitional-styles/transitional-styles.ts
+++ b/libs/core/src/utils/transitional-styles/transitional-styles.ts
@@ -1,31 +1,34 @@
 import { html, HTMLTemplateResult } from 'lit'
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'
 import { GdsElement } from '../../gds-element'
+
+// Only import components here. Primitives should be imported from the components that use them.
+// Also, if a component depens, remember to import transitional styles for teh child component in
+// the parent component. Check how datepicker handles dropdown for an example.
+
 import * as Button from '../../components/button/button.trans.styles'
-import * as Calendar from '../../primitives/calendar/calendar.trans.styles'
+import * as Dropdown from '../../components/dropdown/dropdown.trans.styles'
 import * as ContextMenu from '../../components/context-menu/context-menu.trans.styles'
 import * as Datepicker from '../../components/datepicker/datepicker.trans.styles'
-import * as Dropdown from '../../components/dropdown/dropdown.trans.styles'
 import * as GroupedList from '../../components/grouped-list/grouped-list.trans.styles'
-import * as Listbox from '../../primitives/listbox/listbox.trans.styles'
-import * as Popover from '../../primitives/popover/popover.trans.styles'
-import * as Segment from '../../components/segmented-control/segment/segment.trans.styles'
 import * as SegmentedControl from '../../components/segmented-control/segmented-control.trans.styles'
 import * as Theme from '../../components/theme/theme.trans.styles'
 
 import { VER_SUFFIX } from '../helpers/custom-element-scoping'
 
+/**
+ * Registers transitional styles for all components.
+ *
+ * **Note:** If you are only using a few components, consider registering those
+ * separately instead. That way, any unused styles can get tree shaken away.
+ */
 export const registerTransitionalStyles = () => {
   Theme.register()
   Dropdown.register()
-  Listbox.register()
-  Popover.register()
   ContextMenu.register()
-  Calendar.register()
   Datepicker.register()
   GroupedList.register()
   SegmentedControl.register()
-  Segment.register()
   Button.register()
 }
 
@@ -78,7 +81,6 @@ export class TransitionalStyles {
   }
 
   applyToElement(styleKey: string, sheet: CSSStyleSheet) {
-    
     const element = this.elements.get(styleKey) as GdsElement
     if (!element || !element.shadowRoot) return
 
@@ -127,7 +129,7 @@ export class TransitionalStyles {
 
     const sheet = new CSSStyleSheet()
     sheet.replaceSync(styles)
-    
+
     this.sheets.set(name, sheet)
     this.applyToElement(name, sheet)
   }

--- a/libs/repo-tools/src/executors/build-core-lib/executor.ts
+++ b/libs/repo-tools/src/executors/build-core-lib/executor.ts
@@ -27,6 +27,9 @@ export default async function runExecutor(
         './libs/core/src/components/**/!(*.test|*.style|*.styles).ts',
       ),
 
+      // Transitional styles
+      ...glob.sync('./libs/core/src/components/**/*.trans.styles.ts'),
+
       // Primitives
       // These are considered internal, but it is somtimes neccessary to
       // import directly, for example in our tests.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -17,6 +17,7 @@
     "paths": {
       "@sebgroup/extract": ["libs/extract/src/index.ts"],
       "@sebgroup/green-angular": ["libs/angular/src/index.ts"],
+      "@sebgroup/green-angular/*": ["libs/angular/*"],
       "@sebgroup/green-angular-charts": ["libs/angular-charts/src/index.ts"],
       "@sebgroup/green-angular-dev/*": ["apps/angular-lib-dev/*"],
       "@sebgroup/green-charts": ["libs/charts/src/index.ts"],


### PR DESCRIPTION
This PR expands on #1326 by adding even more sub path exports:
* Enable sub-packages in the Angular lib. Each component can now be imported from a sub path.
* Enable per-component registration of transitional styles. Previously, the CSS for all components would get included even if only a few were used. Now it can be selectively included and registered only for the components that are used.