### PR TITLE
Fix Datepicker/Calendar rendering incorrect month in some cases

### DIFF
--- a/.changeset/stupid-olives-deliver.md
+++ b/.changeset/stupid-olives-deliver.md
@@ -1,0 +1,5 @@
+---
+'@sebgroup/green-core': patch
+---
+
+**Calendar:** Fix issue where the wrong month could be rendered in the calendar, if focused day number was outside the selected month (for example if 30th is focused and February was selected). Fixes #1412

--- a/libs/core/src/primitives/calendar/calendar.test.ts
+++ b/libs/core/src/primitives/calendar/calendar.test.ts
@@ -218,7 +218,7 @@ describe('<gds-calendar>', () => {
       await el.updateComplete
 
       await expect(onlyDate(el.focusedDate)).to.equal(
-        onlyDate(new Date('2024-02-28')),
+        onlyDate(new Date('2024-02-29')),
       )
     })
   })

--- a/libs/core/src/primitives/calendar/calendar.test.ts
+++ b/libs/core/src/primitives/calendar/calendar.test.ts
@@ -205,5 +205,21 @@ describe('<gds-calendar>', () => {
         onlyDate(new Date('2024-02-01')),
       )
     })
+
+    it('should focus last day of month if focused date is beyond last day of current month when changing month', async () => {
+      const el = await fixture<GdsCalendar>(
+        html`<gds-calendar
+          .focusedDate=${new Date('2024-05-31')}
+        ></gds-calendar>`,
+      )
+      await el.updateComplete
+
+      el.focusedMonth = 1
+      await el.updateComplete
+
+      await expect(onlyDate(el.focusedDate)).to.equal(
+        onlyDate(new Date('2024-02-28')),
+      )
+    })
   })
 })

--- a/libs/core/src/primitives/calendar/calendar.ts
+++ b/libs/core/src/primitives/calendar/calendar.ts
@@ -116,7 +116,7 @@ export class GdsCalendar extends GdsElement {
       Math.min(this.focusedDate.getDate(), lastOfSelectedMonth.getDate()),
     )
     newFocusedDate.setMonth(month)
-    newFocusedDate.setHours(0, 0, 0, 0)
+    newFocusedDate.setHours(12, 0, 0, 0)
 
     this.focusedDate = newFocusedDate
   }

--- a/libs/core/src/primitives/calendar/calendar.ts
+++ b/libs/core/src/primitives/calendar/calendar.ts
@@ -10,6 +10,7 @@ import {
   getWeek,
   subMonths,
   addMonths,
+  lastDayOfMonth,
 } from 'date-fns'
 
 import { GdsElement } from '../../gds-element'
@@ -106,10 +107,18 @@ export class GdsCalendar extends GdsElement {
     return this.focusedDate.getMonth()
   }
   set focusedMonth(month: number) {
-    const newDate = new Date(this.focusedDate)
-    newDate.setMonth(month)
-    newDate.setHours(0, 0, 0, 0)
-    this.focusedDate = newDate
+    const lastOfSelectedMonth = lastDayOfMonth(
+      new Date(this.focusedYear, month, 1),
+    )
+    const newFocusedDate = new Date(this.focusedDate)
+
+    newFocusedDate.setDate(
+      Math.min(this.focusedDate.getDate(), lastOfSelectedMonth.getDate()),
+    )
+    newFocusedDate.setMonth(month)
+    newFocusedDate.setHours(0, 0, 0, 0)
+
+    this.focusedDate = newFocusedDate
   }
 
   /**


### PR DESCRIPTION
Fix issue where the wrong month could be rendered in the calendar, if focused day number was outside the selected month (for example if 30th is focused and February was selected)

#1412